### PR TITLE
Added `.clang-format` flie

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,92 @@
+---
+Language: Cpp
+#BasedOnStyle: ??
+AccessModifierOffset: -4
+AlignConsecutiveMacros: false
+AlignAfterOpenBracket: false
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Left
+AlignOperands: false
+AlignTrailingComments: false
+AllowAllArgumentsOnNextLine: false
+AllowAllConstructorInitializersOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: true
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLambdasOnASingleLine: All
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BitFieldColonSpacing: Both
+BreakBeforeBraces: Custom
+BraceWrapping:
+    AfterClass: true
+    AfterControlStatement: true
+    AfterEnum: true
+    AfterFunction: true
+    AfterNamespace: true
+    AfterObjCDeclaration: true
+    AfterStruct: true
+    AfterUnion: true
+    BeforeCatch: true
+    BeforeElse: true
+    BeforeWhile: true
+    IndentBraces: false
+    SplitEmptyFunction: false
+BreakBeforeBinaryOperators: None
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: false
+ColumnLimit: 0
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+IndentCaseLabels: true
+IndentWidth: 4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+#these doesn't matter when `ColumnLimit` is set to 0
+  #PenaltyBreakBeforeFirstCallParameter: 1
+  #PenaltyBreakComment: 300
+  #PenaltyBreakFirstLessLess: 120
+  #PenaltyBreakString: 1000
+  #PenaltyExcessCharacter: 10
+  #PenaltyReturnTypeOnItsOwnLine: 2000
+PointerAlignment: Left
+SortIncludes:    false
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: Never
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyParentheses: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInCStyleCastParentheses: false
+SpacesInConditionalStatement: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard: Auto
+UseCRLF: false
+UseTab: Never
+...


### PR DESCRIPTION
## Formating settings

 - Access modifiers (public/protected/private) will be aligned to the beginning of the line
 - column limit of 0, which means there is no limitation on how many characters may reside on the same line (if coulum limit would be set to N, then clang format would break line (if possible), when character count in that line exceeds N)
 - no tabs
 - indent: 4 spaces
 - short ifs on a single line are not allowed, so for example:
    `if(true) return 0;`
    will be changed to:
    ```
    if(true)
        return 0;
    ```
    same for short loops
 - Allow short lambdas on a single line
 - Do not force break after template declarations
 - Always break before empty braces, so for example:
    ```
    int foo(){
        //..
    }
    ```
    will be changed to:
    ```
    int foo()
    {

    }
    ```
 - constructor initializer list may reside on a single line, no matter how many characters there are
 - always indent `case` labels (4 spaces)
 - remove consecutive empty lines, for example:
    ```
    int a = 0;


    int b = 1;
    ```
    will be changed to:
    ```
    int a = 0;

    int b = 0;
    ```
 - remove namespace indentation
 - pointers and references are always aligned to the type, for example: `T* Ptr`
 - use only LF as a line ending

**Alignment:**
 - Don't align: 
    - params after an open bracket
    - consecutive macros
    - consecutive assignemts
    - consecutive declarations
    - operands
    - consecutive comments
 - Align:
    - escaped lines to the left (multiple line macros)
    