### PR TITLE
Ballot test

### DIFF
--- a/examples_tests/48.ArithmeticUnitTest/main.cpp
+++ b/examples_tests/48.ArithmeticUnitTest/main.cpp
@@ -81,6 +81,17 @@ struct max
 
 	_NBL_STATIC_INLINE_CONSTEXPR const char* name = "max";
 };
+template<typename T>
+struct bitcount
+{
+	using type_t = T;
+	_NBL_STATIC_INLINE_CONSTEXPR T IdentityElement = T(0);
+
+	inline T operator()(T left, T right) { return T(0); }
+
+	_NBL_STATIC_INLINE_CONSTEXPR const char* name = "bitcount";
+};
+
 
 
 //subgroup method emulations on the CPU, to verify the results of the GPU methods
@@ -250,7 +261,7 @@ bool validateResults(video::IVideoDriver* driver, const uint32_t* inputData, con
 
 }
 template<template<class> class Arithmetic>
-bool runTest(video::IVideoDriver* driver, video::IGPUComputePipeline* pipeline, const video::IGPUDescriptorSet* ds, const uint32_t* inputData, const uint32_t workgroupSize, core::smart_refctd_ptr<IGPUBuffer>* const buffers)
+bool runTest(video::IVideoDriver* driver, video::IGPUComputePipeline* pipeline, const video::IGPUDescriptorSet* ds, const uint32_t* inputData, const uint32_t workgroupSize, core::smart_refctd_ptr<IGPUBuffer>* const buffers, bool is_workgroup_test = false)
 {
 	driver->bindComputePipeline(pipeline);
 	driver->bindDescriptorSets(video::EPBP_COMPUTE,pipeline->getLayout(),0u,1u,&ds,nullptr);
@@ -265,6 +276,9 @@ bool runTest(video::IVideoDriver* driver, video::IGPUComputePipeline* pipeline, 
 	passed = validateResults<Arithmetic,mul>(driver, inputData, workgroupSize, workgroupCount, buffers[4].get())&&passed;
 	passed = validateResults<Arithmetic,::min>(driver, inputData, workgroupSize, workgroupCount, buffers[5].get())&&passed;
 	passed = validateResults<Arithmetic,::max>(driver, inputData, workgroupSize, workgroupCount, buffers[6].get())&&passed;
+	if(is_workgroup_test)
+		passed = validateResults<Arithmetic,bitcount>(driver, inputData, workgroupSize, workgroupCount, buffers[7].get()) && passed;
+
 	return passed;
 }
 
@@ -300,43 +314,41 @@ int main()
 	}
 	auto gpuinputDataBuffer = driver->createFilledDeviceLocalGPUBufferOnDedMem(kBufferSize, inputData);
 	
-	//create 7 buffers.
-	core::smart_refctd_ptr<IGPUBuffer> buffers[7];
-	for (size_t i = 0; i < 7; i++)
+	//create 8 buffers.
+	constexpr const int outputBufferCount = 8;
+	constexpr const int totalBufferCount = outputBufferCount+1;
+
+	core::smart_refctd_ptr<IGPUBuffer> buffers[outputBufferCount];
+	for (size_t i = 0; i < outputBufferCount; i++)
 	{
 		buffers[i] = driver->createDeviceLocalGPUBufferOnDedMem(kBufferSize);
 	}
 
-	IGPUDescriptorSetLayout::SBinding binding[8] = {
-		{0u,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr},	//input with randomized numbers
-		{1u,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr},
-		{2u,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr},
-		{3u,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr},
-		{4u,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr},
-		{5u,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr},
-		{6u,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr},
-		{7u,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr},
-	};
-	auto gpuDSLayout = driver->createGPUDescriptorSetLayout(binding, binding + 8);
-	constexpr uint32_t pushconstantSize = 64u;
+	IGPUDescriptorSetLayout::SBinding binding[totalBufferCount];
+	for (uint32_t i = 0u; i < totalBufferCount; i++)
+	{
+		binding[i] = { i,EDT_STORAGE_BUFFER,1u,IGPUSpecializedShader::ESS_COMPUTE,nullptr };
+	}
+	auto gpuDSLayout = driver->createGPUDescriptorSetLayout(binding, binding + totalBufferCount);
+	constexpr uint32_t pushconstantSize = 8u* totalBufferCount;
 	SPushConstantRange pcRange[1] = { IGPUSpecializedShader::ESS_COMPUTE,0u,pushconstantSize };
 	auto pipelineLayout = driver->createGPUPipelineLayout(pcRange, pcRange + pushconstantSize, core::smart_refctd_ptr(gpuDSLayout));
 
 	auto descriptorSet = driver->createGPUDescriptorSet(core::smart_refctd_ptr(gpuDSLayout));
 	{
-		IGPUDescriptorSet::SDescriptorInfo infos[8];
+		IGPUDescriptorSet::SDescriptorInfo infos[totalBufferCount];
 		infos[0].desc = gpuinputDataBuffer;
 		infos[0].buffer = { 0u,kBufferSize };
-		for (uint32_t i=1u; i<=7u; i++)
+		for (uint32_t i=1u; i<= outputBufferCount; i++)
 		{
 			infos[i].desc = buffers[i - 1];
 			infos[i].buffer = { 0u,kBufferSize };
 
 		}
-		IGPUDescriptorSet::SWriteDescriptorSet writes[8];
-		for (uint32_t i=0u; i<8u; i++)
+		IGPUDescriptorSet::SWriteDescriptorSet writes[totalBufferCount];
+		for (uint32_t i=0u; i< totalBufferCount; i++)
 			writes[i] = { descriptorSet.get(),i,0u,1u,EDT_STORAGE_BUFFER,infos + i };
-		driver->updateDescriptorSets(8, writes, 0u, nullptr);
+		driver->updateDescriptorSets(totalBufferCount, writes, 0u, nullptr);
 	}
 	struct GLSLCodeWithWorkgroup {
 		uint32_t workgroup_definition_position;
@@ -391,9 +403,9 @@ int main()
 		passed = runTest<emulatedSubgroupReduction>(driver,pipelines[0u].get(),descriptorSet.get(),inputData,workgroupSize,buffers)&&passed;
 		passed = runTest<emulatedSubgroupScanExclusive>(driver,pipelines[1u].get(),descriptorSet.get(),inputData,workgroupSize,buffers)&&passed;
 		passed = runTest<emulatedSubgroupScanInclusive>(driver,pipelines[2u].get(),descriptorSet.get(),inputData,workgroupSize,buffers)&&passed;
-		passed = runTest<emulatedWorkgroupReduction>(driver,pipelines[3u].get(),descriptorSet.get(),inputData,workgroupSize,buffers)&&passed;
-		passed = runTest<emulatedWorkgroupScanExclusive>(driver,pipelines[4u].get(),descriptorSet.get(),inputData,workgroupSize,buffers)&&passed;
-		passed = runTest<emulatedWorkgroupScanInclusive>(driver,pipelines[5u].get(),descriptorSet.get(),inputData,workgroupSize,buffers)&&passed;
+		passed = runTest<emulatedWorkgroupReduction>(driver,pipelines[3u].get(),descriptorSet.get(),inputData,workgroupSize,buffers,true)&&passed;
+		passed = runTest<emulatedWorkgroupScanExclusive>(driver,pipelines[4u].get(),descriptorSet.get(),inputData,workgroupSize,buffers, true)&&passed;
+		passed = runTest<emulatedWorkgroupScanInclusive>(driver,pipelines[5u].get(),descriptorSet.get(),inputData,workgroupSize,buffers, true)&&passed;
 
 		if (passed)
 			os::Printer::log("Passed test #" + std::to_string(workgroupSize), ELL_INFORMATION);

--- a/examples_tests/48.ArithmeticUnitTest/shaderCommon.glsl
+++ b/examples_tests/48.ArithmeticUnitTest/shaderCommon.glsl
@@ -34,3 +34,7 @@ layout(set = 0, binding = 7, std430) writeonly buffer outmax
 {
     uint maxOutput[];
 };
+layout(set = 0, binding = 8, std430) writeonly buffer outbitcount
+{
+    uint bitCountOutput[];
+};

--- a/examples_tests/48.ArithmeticUnitTest/testWorkgroupExclusive.comp
+++ b/examples_tests/48.ArithmeticUnitTest/testWorkgroupExclusive.comp
@@ -13,4 +13,6 @@ void main()
 	multOutput[gl_GlobalInvocationID.x] = nbl_glsl_workgroupExclusiveMul(sourceVal);
 	minOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupExclusiveMin(sourceVal);
 	maxOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupExclusiveMax(sourceVal);
+	bitCountOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupBallotExclusiveBitCount();
+
 }

--- a/examples_tests/48.ArithmeticUnitTest/testWorkgroupExclusive.comp
+++ b/examples_tests/48.ArithmeticUnitTest/testWorkgroupExclusive.comp
@@ -13,6 +13,7 @@ void main()
 	multOutput[gl_GlobalInvocationID.x] = nbl_glsl_workgroupExclusiveMul(sourceVal);
 	minOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupExclusiveMin(sourceVal);
 	maxOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupExclusiveMax(sourceVal);
+	nbl_glsl_workgroupBallot((sourceVal&0x1u)==0x1u);
 	bitCountOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupBallotExclusiveBitCount();
 
 }

--- a/examples_tests/48.ArithmeticUnitTest/testWorkgroupInclusive.comp
+++ b/examples_tests/48.ArithmeticUnitTest/testWorkgroupInclusive.comp
@@ -13,5 +13,6 @@ void main()
 	multOutput[gl_GlobalInvocationID.x] = nbl_glsl_workgroupInclusiveMul(sourceVal);
 	minOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupInclusiveMin(sourceVal);
 	maxOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupInclusiveMax(sourceVal);
+	nbl_glsl_workgroupBallot((sourceVal&0x1u)==0x1u);
 	bitCountOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupBallotInclusiveBitCount();
 }

--- a/examples_tests/48.ArithmeticUnitTest/testWorkgroupInclusive.comp
+++ b/examples_tests/48.ArithmeticUnitTest/testWorkgroupInclusive.comp
@@ -13,4 +13,5 @@ void main()
 	multOutput[gl_GlobalInvocationID.x] = nbl_glsl_workgroupInclusiveMul(sourceVal);
 	minOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupInclusiveMin(sourceVal);
 	maxOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupInclusiveMax(sourceVal);
+	bitCountOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupBallotInclusiveBitCount();
 }

--- a/examples_tests/48.ArithmeticUnitTest/testWorkgroupReduce.comp
+++ b/examples_tests/48.ArithmeticUnitTest/testWorkgroupReduce.comp
@@ -13,4 +13,6 @@ void main()
 	multOutput[gl_GlobalInvocationID.x] = nbl_glsl_workgroupMul(sourceVal);
 	minOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupMin(sourceVal);
 	maxOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupMax(sourceVal);
+	bitCountOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupBallotBitCount();
+
 }

--- a/examples_tests/48.ArithmeticUnitTest/testWorkgroupReduce.comp
+++ b/examples_tests/48.ArithmeticUnitTest/testWorkgroupReduce.comp
@@ -13,6 +13,7 @@ void main()
 	multOutput[gl_GlobalInvocationID.x] = nbl_glsl_workgroupMul(sourceVal);
 	minOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupMin(sourceVal);
 	maxOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupMax(sourceVal);
+	nbl_glsl_workgroupBallot((sourceVal&0x1u)==0x1u);
 	bitCountOutput [gl_GlobalInvocationID.x] = nbl_glsl_workgroupBallotBitCount();
 
 }

--- a/examples_tests/48.ArithmeticUnitTest/workgroupCommon.glsl
+++ b/examples_tests/48.ArithmeticUnitTest/workgroupCommon.glsl
@@ -1,3 +1,3 @@
 #include "shaderCommon.glsl"
-
+#include "nbl/builtin/glsl/workgroup/ballot.glsl"
 #include "nbl/builtin/glsl/workgroup/arithmetic.glsl"

--- a/examples_tests/48.ArithmeticUnitTest/workgroupCommon.glsl
+++ b/examples_tests/48.ArithmeticUnitTest/workgroupCommon.glsl
@@ -1,3 +1,10 @@
 #include "shaderCommon.glsl"
-#include "nbl/builtin/glsl/workgroup/ballot.glsl"
-#include "nbl/builtin/glsl/workgroup/arithmetic.glsl"
+
+// ORDER OF INCLUDES MATTERS !!!!!
+// first the feature that requires the most shared memory should be included
+// anyway when one is using more than 2 features that rely on shared memory,
+// they should declare the shared memory of appropriate size by themselves.
+// But in this unit test we don't because we need to test if the default
+// sizing macros actually work for all workgroup sizes.
+#include <nbl/builtin/glsl/workgroup/arithmetic.glsl>
+#include <nbl/builtin/glsl/workgroup/ballot.glsl>

--- a/include/nbl/builtin/glsl/workgroup/ballot.glsl
+++ b/include/nbl/builtin/glsl/workgroup/ballot.glsl
@@ -273,7 +273,7 @@ uint nbl_glsl_workgroupBallotScanBitCount_impl(in bool exclusive)
 		barrier();
 	}
 
-	const uint mask = 0xffffffffu>>((exclusive ? 32u:31u)-(gl_LocalInvocationIndex&31u));
+	const uint mask = (exclusive ? 0x7fffffffu:0xffffffffu)>>(31u-(gl_LocalInvocationIndex&31u));
 	return globalCount+bitCount(localBitfield&mask);
 }
 


### PR DESCRIPTION
## Description
Added a test for ballot bit count functions from `nbl/builtin/glsl/workgroup/ballot.glsl` to example 48.ArithmeticUnitTest
Additionally, after merging I encountered problems with CMeshManipulator.cpp, the template parameter count changed. Should this change be undone or is this ok?


## TODO list:
- [x] `#include <nbl/builtin/glsl/subgroup/arithmetic_portability_impl.glsl>` is causing compilation errors, despite the file being where it should be.
- [x] last time, bitCount functions were all returning 0, I need to confirm what the correct, expected output should be. I previously understood it should either return 0 or 1, as the value to be counted was a boolean (which also take values of that range), and it should sum the results of previous invocations within the workgroup.

