### PR TITLE
Master to NewAPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ endif()
 
 #
 get_filename_component(NBL_ROOT_PATH "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
+get_filename_component(NBL_BINARY_PATH "${CMAKE_CURRENT_BINARY_DIR}" ABSOLUTE)
 
 # Configure CCache if available
 find_program(CCACHE_FOUND ccache)
@@ -252,3 +253,5 @@ endif()
 if(NBL_BUILD_DOCS)
 	add_subdirectory(docs)
 endif()
+
+add_subdirectory(artifacts)

--- a/artifacts/CMakeLists.txt
+++ b/artifacts/CMakeLists.txt
@@ -36,5 +36,5 @@ add_custom_target(pack_artifact_ditt
 	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/media/kernels/physical_flare_256.exr ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/media/kernels/physical_flare_256.exr
 	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/media/kernels/physical_flare_512.exr ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/media/kernels/physical_flare_512.exr
 	
-	COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack && cmake -E tar -cvj ../Ditt.tar ./
+	COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/Ditt && cmake -E tar -cvj Ditt.tar.bz2 pack/
 )

--- a/artifacts/CMakeLists.txt
+++ b/artifacts/CMakeLists.txt
@@ -1,0 +1,40 @@
+# Copyright (C) 2018-2022 - DevSH Graphics Programming Sp. z O.O.
+# This file is part of the "Nabla Engine".
+# For conditions of distribution and use, see copyright notice in nabla.h
+
+set(EXAMPLES_TESTS_PATH ${NBL_ROOT_PATH}/examples_tests)
+set(NBL_RAYTRACEDAO_EX_NAME "22.RaytracedAO")
+set(NBL_DENOISER_TONEMAPPER_EX_NAME "39.DenoiserTonemapper")
+
+add_custom_target(pack_artifact_ditt
+	COMMAND cmake -E echo "Archiving the build!"
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/bin/LowDiscrepancySequenceCache.bin ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/bin/LowDiscrepancySequenceCache.bin
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/bin/raytracedao.exe ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/bin/raytracedao.exe
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/closestHit.comp ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/closestHit.comp
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/common.h ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/common.h
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/cull.comp ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/cull.comp
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/denoiser_hook.bat ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/denoiser_hook.bat
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/extractCubemap.bat ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/extractCubemap.bat
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/fillVisBuffer.frag ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/fillVisBuffer.frag
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/fillVisBuffer.vert ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/fillVisBuffer.vert
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/main.cpp ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/main.cpp
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/mergeCubemap.bat ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/mergeCubemap.bat
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/README.md ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/README.md
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/rasterizationCommon.h ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/rasterizationCommon.h
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/raygen.comp ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/raygen.comp
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/raytraceCommon.glsl ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/raytraceCommon.glsl
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/raytraceCommon.h ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/raytraceCommon.h
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/resolve.comp ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/resolve.comp
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/virtualGeometry.glsl ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/virtualGeometry.glsl
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_RAYTRACEDAO_EX_NAME}/virtualGeometry.glsl ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_RAYTRACEDAO_EX_NAME}/virtualGeometry.glsl
+
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_DENOISER_TONEMAPPER_EX_NAME}/bin/denoisertonemapper.exe ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_DENOISER_TONEMAPPER_EX_NAME}/bin/denoisertonemapper.exe
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_DENOISER_TONEMAPPER_EX_NAME}/CommonPushConstants.h ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_DENOISER_TONEMAPPER_EX_NAME}/CommonPushConstants.h
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/${NBL_DENOISER_TONEMAPPER_EX_NAME}/ShaderCommon.glsl ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/${NBL_DENOISER_TONEMAPPER_EX_NAME}/ShaderCommon.glsl
+	
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/media/blueNoiseDithering/LDR_RGBA.png ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/media/blueNoiseDithering/LDR_RGBA.png
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/media/kernels/physical_flare_256.exr ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/media/kernels/physical_flare_256.exr
+	COMMAND cmake -E copy ${EXAMPLES_TESTS_PATH}/media/kernels/physical_flare_512.exr ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack/media/kernels/physical_flare_512.exr
+	
+	COMMAND cd ${CMAKE_CURRENT_BINARY_DIR}/Ditt/pack && cmake -E tar -cvj ../Ditt.tar ./
+)

--- a/examples_tests/22.RaytracedAO/Renderer.h
+++ b/examples_tests/22.RaytracedAO/Renderer.h
@@ -54,7 +54,7 @@ class Renderer : public nbl::core::IReferenceCounted, public nbl::core::Interfac
 		
 		void denoiseCubemapFaces(std::filesystem::path filePaths[6], const std::string& mergedFileName, int borderPixels, const DenoiserArgs& denoiserArgs = {});
 
-		bool render(nbl::ITimer* timer, const bool beauty=true);
+		bool render(nbl::ITimer* timer, const bool transformNormals, const bool beauty=true);
 
 		auto* getColorBuffer() { return m_colorBuffer; }
 


### PR DESCRIPTION
## Description
<!-- Describe what problem this is solving, and how it's solved. -->

1. .gitignore and CmakeLists.txt is all ok to merge
2. The submodules and dependencies
2a. SPIRV-Headers, SPIRV-Tools, glslang, shaderc, SPIRV-Cross don't matter which version they get upgraded to, you should probably get the latest stable anyway, cause that stuff fixes bugs and brings improvements and I do it periodically (careful though, all 4 need to be upgraded in sync cause they depend on each other, upgrading 1by1 wont work)
2b. RadeonRays you can just take from master
2c. Portable File Dialogs, just take latest stable tag
3. Readme, take from New API
4. Examples:
4a. 00 is new and temporary, leave
4b. 09 needs a fix in tryToWrite line 184
4c. 18 merge from master (it doesn't run on newAPI yet)
4d. 20-21 what happens is irrelevant
4e.  22 New API shouldn't have any changes to it, so no conflicts
4f. Denoiser tonemapper changes are trivial and master is authoritative
4g. Ex 41 not ported yet, so you can just take master as authoritative
4h. Ex 42 seems that master messed around with the shaders, while the NewAPI only touched main.cpp
(master disabled MIS, and turned on NEE only with direct lighting, because I was starting some work on spherical rectangle sampling, so port 00 to new API to get the "old pathtracing" look back in some sample) 
4i. Ex43 and 47 master added C++17 execution policies (std::par_unseq) to image filters, so minor change to  test
4j. Ex45 and 46 minor change in builtin decl of nbl_glsl_calcSurfaceInteraction`
5. Don't worry about IDriver.h its a old stub file now on New API 
6. changes in matrix4* are yours 😉
7. minor fixes to IAsset, IImageView, ICPUMesh and IDescriptorSet on master shouldn't impact anything
8. I added some const correctness to IRenderpassIndependentPipeliene's constructor, you should just check the pointers passed during inherited constructor call (COpenGLRenderpassIndependentPipeline already fixed) 
9. I think 80% of all code changes from master are in  include/nbl/asset/filters/ (logic changed) and include/nbl/asset/format (no logic, behaviour or semantics changed, just a DRY cleanup)
10. Many changes in material_compiler are basically stylistic changes
11. CDerivativeMapMetadata is a new type of asset metadata we can add to IImageView SAssetBundles
12. Added IImageViewMetadata to let us know the color space and OETF of images
13. Some upgrades (basically the V2 variant for programmable pulling) to Mesh Packers from master, but AFAIK no example with MEsh Packing on New API ported yet (przemog_port branch?) 
14. Added some stuff for barycentric coord compuation in shaders (for visbuffer renderers) to builtin GLSL lib, and also stuff added to COpenGLShader.h which you'll neeed to port to New API @Erfan 
15. I did some namespace scoping of FLT_MIN etc to nbl_glsl_FLT_MIN
16. COpenGLDescriptorSet.h Fix for buggy drivers, and making sure we keep the GLenum targets and formats for STORAGE_IMAGE bindings on GL (new API doesn't have this, useful to merge!)
17. COpenGLDriver + COpenGLExtensionHandler are now dead files, and has mostly irrelavant changes. BUT YOU @Erfan MUST PORT THE IsIntelGPU StorageImageMultibind workaround to new API (might fix OIT on chromebook).
18. I modified Radeon Rays 2.0 to have slimmer ray and intersection structs, so changed our ext::GLSL to match
19. Minor correctness, performance and style fixes to GLSL lib; Fresnel. nbl_glsl_getArccosSumofABC_minus_PI and slerp
20. Fixes to  Projected and Regular Spherical Triangle sampling, the old routines weren't numerically robust enough to handle long thin triangles (also reason for why ex 42 has changed)
21. Changed the Importance Sampling (generate) functions and similar utilities to take a inout vec3 instead of an in vec3 to return rescaled random variable when sampling a discrete distribution.
(This way we can re-use the Z coordinate to make further independent choices in discrete distributions) 
22. Added in uint drawID to nbl_glsl_fetchVtxPos (needed for easy Virtual Geometry / Mesh Packer overrides for preloaded meshes)
23. Dropped the dUV argument in nbl_computeLighting and nbl_bsdf_cos_eval WARNING: @Erfan  & @0x45 this will break other builtin shaders added since the divergence of New API (e.g. glTF shaders) 
24. Update MTL built-in shaders to conform with new bump-mapping API, also support the bumpmap scale material parameter (via minor changes to CGraphicsPipelineLoaderMTL)!
25. Minor fixes to OBJ loader, like erasing empty/invalid meshbuffers and finally setting the normal attribute index
26. Derivative Map Creator properly supports normalization (so you have control over when the pixel values get clamped), also correctness fixes 
27. Minor but important bugfix to GeneralpurposeAddressAllocator
28. added GLSL like atomicMax and atomicMin to C++
29. Your Changes to radians and degrees although you @Erfan  should allow the type to also be vectorSIMDf
30. More Morton Code functions (used mesh packer V2)
31. Minor comments and fixes to core::rational
32. Radeon Rays extension C++ has the matrix precision fix, as well as the unlinkBuffer fix which fixes the leaks and hangs when switching scenes.
33. ScreenShot.h has added stuff for convert filter parallelization and the flip output option
34. Changed default minimum allocation size (round up to size) from 1kb to 64 bytes on the StreamingTransientDataBuffer
35. Added some utils to glsl/limits/numeric.glsl which you should be familiar with from the robust intesection stuff
36. Added RGB10A2_SNORM encode to encode.glsl and  did some common code factorization
37. I did some slight rework of bump_mapping/utils.glsl basically rewrote the whole thing
38. @Erfan you need to remove your IMF::Istream overload for EXR reader, and take the one made by @0x45 he did when porting the loader to New API
39. Mesh Packer / Virtual Geometry (Mesh Packer V2 is VG) improvements
39a. virtual_geometry/descriptors.glsl
39b. virtual_attribute.glsl nice packed (single uint) and unpacked struct for knowing what descriptor and what offset your programmable vertex fetch attributes come from 😉
39c. virtual_attribute_fetch.glsl with nice nbl_glsl_VG_attribFetch_{$FORMAT} functions
40. Virtual Texturing changes
40a. Added _NBL_ prefix to macros
40b. Bugfixes for attempting to pack a texture smaller than the Virtual Page size into VT, and some mip tail stuff (stuff Yoran showed us in 4k textures)
40c. Sampler parameters for non-float format views, but there's still a TODO for @criss which now goes to you @Erfan about using non float samplers with non float views IVirtualTExture.h
41. Material Compiler Changes:
41a. GLSL Backend:
41a.i. Generator Stream Type (added option for AOV extraction)
41b. common.glsl shader
41b.i. comments and TODOs updated
41b.ii. readibility and strong typing improvements (src,dst register struct, separate retval structs for eval and rem_and_pdf functions)
41b.iii. AoV computation logic
41b.iv. Read and Write Virtual Register functions are now done as nice overrides (same function name always)
41b.v. Lots of fixes to correctness and perf of Diffuse Coating BxDF modifier, and BLEND modifier
41b.vi. Refactor common code to generate, eval_and_pdf, remainder_and_pdf, and regular raster eval and do some correctness fixes
41c. Common to all Backends:
41c.i. some indendation stuff and privateizing certain methods and variables, and more comments
41c.ii. My fix to the above to use a Conductor as a Coating over diffuse (instead of Dielectric, it makes sense for perf and fresnel evaluation reasons)
41c.iii. Rename registerPool into regsiterBudget for better readiability
41c.iv. createUpscaledImage from Virtual Texturing class before allocation, for the image < page size bug
41c.v. fix a bug in the translation of MASK IR element (blend between child BxDF and pure transmission was wrong way round)
41c.vi. better error handling for invalid coating (non diffuse BRDF coatee)
41c.vii. Support the different Generator Stream Types in the register consumption calculation
42. src/nbl/ext/MitsubaLoader are:
42a. pretty much only changes I've asked you to make
42b. adjusting to the above changes in GLSL library and material compilter GLSL
42c. SContext and CMitsubaMaterialCompilerFrontend changes how we cache derived images and their views (i.e. channel extracted image, dervative map) to ensure no duplicate work and fix bugs with cache key collision
42d. Fix the Derivative Map computation so its insensitive to texture resolution, also store normalization factor
42e. fix front/back face detection
42f. Loader cross integration fixes:
42f.i. Tag the Normal Attribute in shapes created with geometry creator
42f.ii. stop making shallow copies of meshbuffers (use metadata properly)
42f.iii. Support flipTexCoords in the <shape> tag
42f.iv. Convert SRGB vertex colour buffer of the PLY mesh to RGB10A2 (handle gamma as mitsuba wants to interpret it)
42f.v. Support surface flipping and normal recomputation
43. Nuke SDL2