### PR TITLE
Add Vulkan 1.3 version to Vulkan version validation and Add Spir-v 1.6

### DIFF
--- a/include/nbl/asset/utils/IGLSLCompiler.h
+++ b/include/nbl/asset/utils/IGLSLCompiler.h
@@ -31,6 +31,7 @@ class IGLSLCompiler final : public core::IReferenceCounted
 			ESV_1_3 = 0x010300u,
 			ESV_1_4 = 0x010400u,
 			ESV_1_5 = 0x010500u,
+			ESV_1_6 = 0x010600u,
 			ESV_COUNT = 0x7FFFFFFFu
 		};
 

--- a/src/nbl/video/CVulkanPhysicalDevice.h
+++ b/src/nbl/video/CVulkanPhysicalDevice.h
@@ -86,6 +86,7 @@ public:
                 [NO NABALA SUPPORT] Vulkan 1.0 implementation must support the 1.0 version of SPIR-V and the 1.0 version of the SPIR-V Extended Instructions for GLSL. If the VK_KHR_spirv_1_4 extension is enabled, the implementation must additionally support the 1.4 version of SPIR-V.
                 A Vulkan 1.1 implementation must support the 1.0, 1.1, 1.2, and 1.3 versions of SPIR-V and the 1.0 version of the SPIR-V Extended Instructions for GLSL.
                 A Vulkan 1.2 implementation must support the 1.0, 1.1, 1.2, 1.3, 1.4, and 1.5 versions of SPIR-V and the 1.0 version of the SPIR-V Extended Instructions for GLSL.
+                A Vulkan 1.3 implementation must support the 1.0, 1.1, 1.2, 1.3, 1.4, and 1.5 versions of SPIR-V and the 1.0 version of the SPIR-V Extended Instructions for GLSL.
             */
             
             uint32_t apiVersion = std::min(instanceApiVersion, deviceProperties.properties.apiVersion);
@@ -103,6 +104,9 @@ public:
                 break;
             case 2:
                 m_limits.spirvVersion = asset::IGLSLCompiler::ESV_1_5;
+                break;
+            case 3:
+                m_limits.spirvVersion = asset::IGLSLCompiler::ESV_1_5; // TODO: change this to spirv 1.6
                 break;
             default:
                 _NBL_DEBUG_BREAK_IF("Invalid Vulkan minor version!");


### PR DESCRIPTION
## Description
I added Vulkan 1.3 version to Vulkan version validation. To prevent show breakpoint ("Invalid Vulkan minor version!") when using Vulkan 1.3 SDK.

## Testing 
<!-- Explain how this change was tested. -->

## TODO list:
<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
