### PR TITLE
Spherical rectangle sampling

### DIFF
--- a/include/nbl/builtin/glsl/math/functions.glsl
+++ b/include/nbl/builtin/glsl/math/functions.glsl
@@ -291,6 +291,31 @@ float nbl_glsl_getArccosSumofABC_minus_PI(in float cosA, in float cosB, in float
 	return ((something0 ? something2:something1) ? (-absArccosSumABC):absArccosSumABC)+(something0||something1 ? nbl_glsl_PI:(-nbl_glsl_PI));
 }
 
+vec2 nbl_glsl_combineCosForSumOfAcos(in vec2 cosA, in vec2 cosB) 
+{
+   const float bias = cosA.y + cosB.y;
+   const float a = cosA.x;
+   const float b = cosB.x;
+   const bool reverse = abs(min(a,b)) > max(a,b);
+   const float c = a*b - sqrt((1.0f-a*a)*(1.0f-b*b));
+   return reverse ? vec2(-c, bias + nbl_glsl_PI) : vec2(c, bias);
+}
+
+// returns acos(a) + acos(b)
+float nbl_glsl_getSumofArccosAB(in float cosA, in float cosB) 
+{
+   const vec2 combinedCos = nbl_glsl_combineCosForSumOfAcos(vec2(cosA, 0.0f), vec2(cosB, 0.0f));
+   return acos(combinedCos.x) + combinedCos.y;
+}
+
+// returns acos(a) + acos(b) + acos(c) + acos(d)
+float nbl_glsl_getSumofArccosABCD(in float cosA, in float cosB, in float cosC, in float cosD) 
+{
+   const vec2 combinedCos0 = nbl_glsl_combineCosForSumOfAcos(vec2(cosA, 0.0f), vec2(cosB, 0.0f));
+   const vec2 combinedCos1 = nbl_glsl_combineCosForSumOfAcos(vec2(cosC, 0.0f), vec2(cosD, 0.0f));
+   const vec2 combinedCos = nbl_glsl_combineCosForSumOfAcos(combinedCos0, combinedCos1);
+   return acos(combinedCos.x) + combinedCos.y;
+}
 
 //! MVC
 

--- a/include/nbl/builtin/glsl/sampling/spherical_rectangle.glsl
+++ b/include/nbl/builtin/glsl/sampling/spherical_rectangle.glsl
@@ -9,8 +9,25 @@
 #include <nbl/builtin/glsl/shapes/rectangle.glsl>
 
 // Code from https://www.arnoldrenderer.com/research/egsr2013_spherical_rectangle.pdf
-vec2 nbl_glsl_sampling_generateSphericalRectangleSample(vec3 r0, in vec2 rectangleExtents, in float S, in float b0, float b1, in float k, vec2 uv)
+vec2 nbl_glsl_sampling_generateSphericalRectangleSample(vec3 r0, in vec2 rectangleExtents, in vec2 uv, out float S)
 {
+    const vec4 denorm_n_z = vec4(-r0.y, r0.x+rectangleExtents.x, r0.y+rectangleExtents.y, -r0.x);
+    const vec4 n_z = denorm_n_z*inversesqrt(vec4(r0.z*r0.z)+denorm_n_z*denorm_n_z);
+    const vec4 cosGamma = vec4(
+        -n_z[0]*n_z[1],
+        -n_z[1]*n_z[2],
+        -n_z[2]*n_z[3],
+        -n_z[3]*n_z[0]
+    );
+    
+    float p = nbl_glsl_getSumofArccosAB(cosGamma[0], cosGamma[1]);
+    float q = nbl_glsl_getSumofArccosAB(cosGamma[2], cosGamma[3]);
+
+    const float k = 2*nbl_glsl_PI - q;
+    const float b0 = n_z[0];
+    const float b1 = n_z[2];
+    S = p + q - 2*nbl_glsl_PI;
+
     const float CLAMP_EPS = 1e-5f;
 
     // flip z axsis if r0.z > 0

--- a/include/nbl/builtin/glsl/sampling/spherical_rectangle.glsl
+++ b/include/nbl/builtin/glsl/sampling/spherical_rectangle.glsl
@@ -1,0 +1,34 @@
+// Copyright (C) 2018-2022 - DevSH Graphics Programming Sp. z O.O.
+// This file is part of the "Nabla Engine".
+// For conditions of distribution and use, see copyright notice in nabla.h
+
+#ifndef _NBL_BUILTIN_GLSL_SAMPLING_SPHERICAL_RECTANGLE_INCLUDED_
+#define _NBL_BUILTIN_GLSL_SAMPLING_SPHERICAL_RECTANGLE_INCLUDED_
+
+#include <nbl/builtin/glsl/math/quaternions.glsl>
+#include <nbl/builtin/glsl/shapes/rectangle.glsl>
+
+#define CLAMP_EPS 1e-5f
+
+// Code from https://www.arnoldrenderer.com/research/egsr2013_spherical_rectangle.pdf
+vec3 nbl_glsl_sampling_generateSphericalRectangleSample(in vec3 r0, in vec3 r1, in float S, in float b0, float b1, in float k, vec2 uv)
+{
+    // 1. compute ’cu’
+    float au = uv.x * S + k;
+    float fu = (cos(au) * b0 - b1) / sin(au);
+    float cu = 1/sqrt(fu*fu + b0 * b0) * (fu>0 ? +1 : -1);
+    cu = clamp(cu, -1, 1); // avoid NaNs
+    // 2. compute ’xu’
+    float xu = -(cu * r0.z) / sqrt(1 - cu*cu);
+    xu = clamp(xu, r0.x, r1.x); // avoid Infs
+    // 3. compute ’yv’
+    float d = sqrt(xu*xu + r0.z*r0.z);
+    float h0 = r0.y / sqrt(d*d + r0.y*r0.y);
+    float h1 = r1.y / sqrt(d*d + r1.y*r1.y);
+    float hv = h0 + uv.y * (h1-h0), hv2 = hv*hv;
+    float yv = (hv2 < 1-CLAMP_EPS) ? (hv*d)/sqrt(1-hv2) : r1.y;
+    // 4. transform (xu,yv,z0) to world coords
+    return vec3(xu, yv, r0.z);
+}
+
+#endif

--- a/include/nbl/builtin/glsl/sampling/spherical_rectangle.glsl
+++ b/include/nbl/builtin/glsl/sampling/spherical_rectangle.glsl
@@ -8,27 +8,32 @@
 #include <nbl/builtin/glsl/math/quaternions.glsl>
 #include <nbl/builtin/glsl/shapes/rectangle.glsl>
 
-#define CLAMP_EPS 1e-5f
-
 // Code from https://www.arnoldrenderer.com/research/egsr2013_spherical_rectangle.pdf
-vec3 nbl_glsl_sampling_generateSphericalRectangleSample(in vec3 r0, in vec3 r1, in float S, in float b0, float b1, in float k, vec2 uv)
+vec2 nbl_glsl_sampling_generateSphericalRectangleSample(vec3 r0, in vec2 rectangleExtents, in float S, in float b0, float b1, in float k, vec2 uv)
 {
-    // 1. compute ’cu’
-    float au = uv.x * S + k;
-    float fu = (cos(au) * b0 - b1) / sin(au);
-    float cu = 1/sqrt(fu*fu + b0 * b0) * (fu>0 ? +1 : -1);
-    cu = clamp(cu, -1, 1); // avoid NaNs
-    // 2. compute ’xu’
-    float xu = -(cu * r0.z) / sqrt(1 - cu*cu);
+    const float CLAMP_EPS = 1e-5f;
+
+    // flip z axsis if r0.z > 0
+    const uint zFlipMask = (floatBitsToUint(r0.z)^0x80000000u)&0x80000000u;
+    r0.z = uintBitsToFloat(floatBitsToUint(r0.z)^zFlipMask);
+    vec3 r1 = r0 + vec3(rectangleExtents.x, rectangleExtents.y, 0);
+    
+    const float au = uv.x * S + k;
+    const float fu = (cos(au) * b0 - b1) / sin(au);
+    const float cu_2 = max(fu*fu+b0*b0,1.f); // forces `cu` to be in [-1,1]
+    const float cu = uintBitsToFloat(floatBitsToUint(inversesqrt(cu_2))^(floatBitsToUint(fu)&0x80000000u));
+    
+    float xu = -(cu * r0.z) * inversesqrt(1 - cu*cu);
     xu = clamp(xu, r0.x, r1.x); // avoid Infs
-    // 3. compute ’yv’
-    float d = sqrt(xu*xu + r0.z*r0.z);
-    float h0 = r0.y / sqrt(d*d + r0.y*r0.y);
-    float h1 = r1.y / sqrt(d*d + r1.y*r1.y);
-    float hv = h0 + uv.y * (h1-h0), hv2 = hv*hv;
-    float yv = (hv2 < 1-CLAMP_EPS) ? (hv*d)/sqrt(1-hv2) : r1.y;
-    // 4. transform (xu,yv,z0) to world coords
-    return vec3(xu, yv, r0.z);
+    const float d_2 = xu*xu + r0.z*r0.z;
+    const float d = sqrt(d_2);
+
+    const float h0 = r0.y * inversesqrt(d_2 + r0.y*r0.y);
+    const float h1 = r1.y * inversesqrt(d_2 + r1.y*r1.y);
+    const float hv = h0 + uv.y * (h1-h0), hv2 = hv*hv;
+    const float yv = (hv2 < 1-CLAMP_EPS) ? (hv*d)*inversesqrt(1-hv2) : r1.y;
+
+    return vec2((xu-r0.x)/rectangleExtents.x, (yv-r0.y)/rectangleExtents.y);
 }
 
 #endif

--- a/include/nbl/builtin/glsl/shapes/rectangle.glsl
+++ b/include/nbl/builtin/glsl/shapes/rectangle.glsl
@@ -1,0 +1,62 @@
+// Copyright (C) 2018-2022 - DevSH Graphics Programming Sp. z O.O.
+// This file is part of the "Nabla Engine".
+// For conditions of distribution and use, see copyright notice in nabla.h
+
+#ifndef _NBL_BUILTIN_GLSL_SHAPES_RECTANGLE_INCLUDED_
+#define _NBL_BUILTIN_GLSL_SHAPES_RECTANGLE_INCLUDED_
+
+#include <nbl/builtin/glsl/math/functions.glsl>
+
+struct SphRect {
+    mat3 basis;
+    vec3 r0;
+    vec3 r1;
+};
+
+SphRect nbl_glsl_shapes_getSphericalRectangle(in vec3 start, in vec3 ex, in vec3 ey, in vec3 origin) 
+{
+    const float exl = length(ex);
+    const float eyl = length(ey);
+    const vec3 x = ex / exl;
+    const vec3 y = ey / eyl;
+    vec3 z = normalize(cross(x, y));
+    if (dot(start-origin, z) > 0) {
+        z*=-1;
+    }
+
+    const mat3 basis = mat3(x, y, z);
+    const vec3 r0 = (start-origin) * basis;
+    const vec3 r1 = r0 + vec3(exl, eyl, 0);
+
+    SphRect rect;
+    rect.basis = basis;
+    rect.r0 = r0;
+    rect.r1 = r1;
+    return rect;
+}
+
+float nbl_glsl_shapes_SolidAngleOfRectangle(in vec3 r0, in vec3 r1, out float b0, out float b1, out float k) 
+{
+    const vec3 v00 = vec3(r0.x, r0.y, r0.z);
+    const vec3 v01 = vec3(r0.x, r1.y, r0.z);
+    const vec3 v10 = vec3(r1.x, r0.y, r0.z);
+    const vec3 v11 = vec3(r1.x, r1.y, r0.z);
+
+    const vec3 n0 = normalize(cross(v00, v10));
+    const vec3 n1 = normalize(cross(v10, v11));
+    const vec3 n2 = normalize(cross(v11, v01));
+    const vec3 n3 = normalize(cross(v01, v00));
+
+    const float g0 = acos(-n0.z * n1.z);
+    const float g1 = acos(-n1.z * n2.z);
+    const float g2 = acos(-n2.z * n3.z);
+    const float g3 = acos(-n3.z * n0.z);
+
+    k = 2*nbl_glsl_PI - g2 - g3;
+    b0 = n0.z;
+    b1 = n2.z;
+
+    return g0 + g1 + g2 + g3 - 2*nbl_glsl_PI;
+}
+
+#endif

--- a/include/nbl/builtin/glsl/shapes/rectangle.glsl
+++ b/include/nbl/builtin/glsl/shapes/rectangle.glsl
@@ -12,7 +12,7 @@ vec3 nbl_glsl_shapes_getSphericalRectangle(in vec3 observer, in vec3 rectangleOr
     return (rectangleOrigin-observer) * rectangleNormalBasis;
 }
 
-float nbl_glsl_shapes_SolidAngleOfRectangle(in vec3 r0, in vec2 rectangleExtents, out float b0, out float b1, out float k) 
+float nbl_glsl_shapes_SolidAngleOfRectangle(in vec3 r0, in vec2 rectangleExtents) 
 {
     const vec4 denorm_n_z = vec4(-r0.y, r0.x+rectangleExtents.x, r0.y+rectangleExtents.y, -r0.x);
     const vec4 n_z = denorm_n_z*inversesqrt(vec4(r0.z*r0.z)+denorm_n_z*denorm_n_z);
@@ -22,13 +22,7 @@ float nbl_glsl_shapes_SolidAngleOfRectangle(in vec3 r0, in vec2 rectangleExtents
         -n_z[2]*n_z[3],
         -n_z[3]*n_z[0]
     );
-    
-    const vec4 g = acos(cosGamma);
-
-    k = 2*nbl_glsl_PI - g[2] - g[3];
-    b0 = n_z[0];
-    b1 = n_z[2];
-    return g[0] + g[1] + g[2] + g[3] - 2*nbl_glsl_PI;
+    return nbl_glsl_getSumofArccosABCD(cosGamma[0], cosGamma[1], cosGamma[2], cosGamma[3]) - 2*nbl_glsl_PI;
 }
 
 #endif

--- a/src/nbl/builtin/CMakeLists.txt
+++ b/src/nbl/builtin/CMakeLists.txt
@@ -132,7 +132,7 @@ set(nbl_resources_to_embed
   "nbl/builtin/glsl/sampling/cos_weighted.glsl"
   "nbl/builtin/glsl/sampling/linear.glsl"
   "nbl/builtin/glsl/sampling/projected_spherical_triangle.glsl"
-  #"nbl/builtin/glsl/sampling/spherical_rectangle.glsl"
+  "nbl/builtin/glsl/sampling/spherical_rectangle.glsl"
   "nbl/builtin/glsl/sampling/spherical_triangle.glsl"
   "nbl/builtin/glsl/sampling/quantized_sequence.glsl"
   # global exclusive scan
@@ -150,7 +150,7 @@ set(nbl_resources_to_embed
   # shapes
   "nbl/builtin/glsl/shapes/aabb.glsl"
   "nbl/builtin/glsl/shapes/frustum.glsl"
-  #"nbl/builtin/glsl/shapes/rectangle.glsl"
+  "nbl/builtin/glsl/shapes/rectangle.glsl"
   "nbl/builtin/glsl/shapes/triangle.glsl"
   # skinning
   "nbl/builtin/glsl/skinning/cache_descriptor_set.glsl"


### PR DESCRIPTION
## Description
This is an implementation of spherical rectangle sampling that can potentially improve convergence of scenes with rectangular light source. It's basically an implementation of the paper below with possibly additional optimizations.

https://www.arnoldrenderer.com/research/egsr2013_spherical_rectangle.pdf

## Testing 
It was compared with triangle reference implmentation and they match the same output by my eye balling.

## TODO list:
- [x] Optimize trigonometry calls
- [x] to be added