### PR TITLE
BUGFIX for Builtin Resources Target Failing on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,12 +311,6 @@ on each submodule's directory required!
 
 ### CMake notes
 
-#### Make sure Python's executable is found
-
-- The paragraph concerns *Windows system* only
-
-Unfortunately on Windows there are often troubles with **Python 3.0+** versions, because it isn't able to find and determine `PYTHON_EXECUTABLE` variable, so you have to fill it manually. If you use **CMake-GUI** you will find it in advanced options.
-
 #### Consider CMake and Visual Studio version, **important**! 
 
 - The paragraph concerns *Visual Studio* only

--- a/src/nbl/builtin/CMakeLists.txt
+++ b/src/nbl/builtin/CMakeLists.txt
@@ -6,11 +6,18 @@ function(nbl_add_builtin_resources)
   list(APPEND builtin_dependencies_list  ${CMAKE_CURRENT_SOURCE_DIR}/builtin/builtinHeaderGen.py)
   list(APPEND builtin_dependencies_list  ${CMAKE_CURRENT_SOURCE_DIR}/builtin/builtinDataGen.py)
 
+  # Just in case if not found yet (3rd parties should've found it already though regardless of platform)
+  find_package(Python3 REQUIRED)
+
+  set(RESOURCES_FILE ${CMAKE_BINARY_DIR}/include/nbl/builtin/resources.txt)
+
+  string(REPLACE ";" "," RESOURCES_ARGS "${ARGV}")
   file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/include/nbl/builtin/)
+  file(WRITE ${RESOURCES_FILE} ${RESOURCES_ARGS})
   add_custom_command(
     OUTPUT "${CMAKE_BINARY_DIR}/include/nbl/builtin/builtinResources.h" "${CMAKE_CURRENT_BINARY_DIR}/builtin/builtinResourceData.cpp"
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/builtin/builtinHeaderGen.py ${CMAKE_BINARY_DIR}/include/nbl/builtin/builtinResources.h ${CMAKE_SOURCE_DIR}/include "${ARGV}"
-    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/builtin/builtinDataGen.py ${CMAKE_CURRENT_BINARY_DIR}/builtin/builtinResourceData.cpp ${CMAKE_SOURCE_DIR}/include "${ARGV}"
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/builtin/builtinHeaderGen.py ${CMAKE_BINARY_DIR}/include/nbl/builtin/builtinResources.h ${CMAKE_SOURCE_DIR}/include ${RESOURCES_FILE}
+    COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/builtin/builtinDataGen.py ${CMAKE_CURRENT_BINARY_DIR}/builtin/builtinResourceData.cpp ${CMAKE_SOURCE_DIR}/include ${RESOURCES_FILE}
     COMMENT "Generated built-in resources"
     DEPENDS ${builtin_dependencies_list}
     VERBATIM  

--- a/src/nbl/builtin/builtinDataGen.py
+++ b/src/nbl/builtin/builtinDataGen.py
@@ -17,10 +17,12 @@ else:
     #arguments
     outputFilename = sys.argv[1]
     cmakeSourceDir = sys.argv[2]
-    resourcePaths = sys.argv[3].split(';')
+    resourcesFile  = sys.argv[3]
+
+    with open(resourcesFile, "r") as f:
+        resourcePaths = f.read().rstrip().split(',')
+
     #opening a file
-
-
     outp = open(outputFilename,"w+")
   
     outp.write("#include <stdlib.h>\n")

--- a/src/nbl/builtin/builtinHeaderGen.py
+++ b/src/nbl/builtin/builtinHeaderGen.py
@@ -15,7 +15,10 @@ else:
     #arguments
     outputFilename = sys.argv[1]
     cmakeSourceDir = sys.argv[2]
-    resourcePaths = sys.argv[3].split(';')
+    resourcesFile  = sys.argv[3]
+
+    with open(resourcesFile, "r") as f:
+        resourcePaths = f.read().rstrip().split(',')
 
     #opening a file
     outp = open(outputFilename,"w+")


### PR DESCRIPTION

## Description

Builtin resources cannot be generated automatically with default windows API, due to an OS limit, as it cannot accept a command line instruction with parameters and length longer than a certain limit. Therefore, the instruction is invalid (currently the length of the cli instruction is more than 8191 characters, hence it fails).

One solution is to transform the command into a bash command which can take long arguments. However, it still needs to be manipulated manually as the required cmake paths point to a Windows location than a mounted location on WSL/bash. 

The best solution is to write all resource address into a file and make the build to read from the file to generate the builtin resources files which this PR represents.

### References

- https://docs.microsoft.com/en-us/troubleshoot/windows-client/shell-experience/command-line-string-limitation
- https://stackoverflow.com/questions/3205027/maximum-length-of-command-line-string
- https://stackoverflow.com/questions/19354870/bash-command-line-and-input-limit

## Testing 
<!-- Explain how this change was tested. -->

## TODO list:
<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
