### PR TITLE
Feature API

### DIFF
--- a/examples_tests/0.ImportanceSamplingEnvMaps/main.cpp
+++ b/examples_tests/0.ImportanceSamplingEnvMaps/main.cpp
@@ -795,7 +795,7 @@ public:
 			fence = logicalDevice->createFence(static_cast<video::IGPUFence::E_CREATE_FLAGS>(0));
 
 		commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-		commandBuffer->begin(0);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 		const auto nextPresentationTimestamp = oracle.acquireNextImage(swapchain.get(), imageAcquire[resourceIx].get(), nullptr, &acquiredNextFBO);
 		{

--- a/examples_tests/01.HelloWorld/main.cpp
+++ b/examples_tests/01.HelloWorld/main.cpp
@@ -532,7 +532,7 @@ Choose Graphics API:
 		else
 			fence = device->createFence(static_cast<video::IGPUFence::E_CREATE_FLAGS>(0));
 
-		commandBuffer->begin(0u);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 		swapchain->acquireNextImage(MAX_TIMEOUT, m_imageAcquire[m_resourceIx].get(), nullptr, &m_acquiredNextFBO);
 

--- a/examples_tests/02.ComputeShader/main.cpp
+++ b/examples_tests/02.ComputeShader/main.cpp
@@ -404,7 +404,7 @@ public:
 		swapchain->acquireNextImage(MAX_TIMEOUT, m_imageAcquire[m_resourceIx].get(), nullptr, &imgnum);
 
 		// safe to proceed
-		cb->begin(0);
+		cb->begin(IGPUCommandBuffer::EU_NONE);
 
 		{
 			asset::SViewport vp;

--- a/examples_tests/03.GPU_Mesh/main.cpp
+++ b/examples_tests/03.GPU_Mesh/main.cpp
@@ -260,7 +260,7 @@ public:
 		const auto& mvp = camera.getConcatenatedMatrix();
 
 		commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-		commandBuffer->begin(0);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 		asset::SViewport viewport;
 		viewport.minDepth = 1.f;

--- a/examples_tests/05.NablaTutorialExample/main.cpp
+++ b/examples_tests/05.NablaTutorialExample/main.cpp
@@ -503,7 +503,7 @@ public:
 		const auto& viewProjectionMatrix = camera.getConcatenatedMatrix();
 
 		commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-		commandBuffer->begin(0);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 		asset::SViewport viewport;
 		viewport.minDepth = 1.f;

--- a/examples_tests/06.MeshLoaders/main.cpp
+++ b/examples_tests/06.MeshLoaders/main.cpp
@@ -420,7 +420,7 @@ public:
             fence = logicalDevice->createFence(static_cast<video::IGPUFence::E_CREATE_FLAGS>(0));
 
         commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-        commandBuffer->begin(0);
+        commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
         const auto nextPresentationTimestamp = oracle.acquireNextImage(swapchain.get(), imageAcquire[resourceIx].get(), nullptr, &acquiredNextFBO);
         {

--- a/examples_tests/07.SubpassBaking/main.cpp
+++ b/examples_tests/07.SubpassBaking/main.cpp
@@ -411,7 +411,7 @@ public:
                 auto fence = logicalDevice->createFence(video::IGPUFence::ECF_UNSIGNALED);
                 core::smart_refctd_ptr<video::IGPUCommandBuffer> tferCmdBuf;
                 logicalDevice->createCommandBuffers(commandPools[decltype(initOutput)::EQT_TRANSFER_UP].get(), video::IGPUCommandBuffer::EL_PRIMARY, 1u, &tferCmdBuf);
-                tferCmdBuf->begin(0u); // TODO some one time submit bit or something
+                tferCmdBuf->begin(IGPUCommandBuffer::EU_NONE); // TODO some one time submit bit or something
                 {
                     auto* ppHandler = utilities->getDefaultPropertyPoolHandler();
                     // if we did multiple transfers, we'd reuse the scratch
@@ -503,7 +503,7 @@ public:
 
         //
         commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-        commandBuffer->begin(0);
+        commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
         // late latch input
         const auto nextPresentationTimestamp = oracle.acquireNextImage(swapchain.get(), imageAcquire[resourceIx].get(), nullptr, &acquiredNextFBO);

--- a/examples_tests/09.ColorSpaceTest/main.cpp
+++ b/examples_tests/09.ColorSpaceTest/main.cpp
@@ -371,7 +371,7 @@ public:
 				// acquire image 
 				swapchain->acquireNextImage(MAX_TIMEOUT, imageAcquire[resourceIx].get(), nullptr, &imgnum);
 
-				cb->begin(0);
+				cb->begin(IGPUCommandBuffer::EU_NONE);
 
 				asset::SViewport viewport;
 				viewport.minDepth = 1.f;

--- a/examples_tests/11.LoDSystem/main.cpp
+++ b/examples_tests/11.LoDSystem/main.cpp
@@ -649,7 +649,7 @@ class LoDSystemApp : public ApplicationBase
                         core::smart_refctd_ptr<video::IGPUCommandBuffer> tferCmdBuf;
                         logicalDevice->createCommandBuffers(commandPools[CommonAPI::InitOutput::EQT_TRANSFER_UP].get(), video::IGPUCommandBuffer::EL_PRIMARY, 1u, &tferCmdBuf);
                         auto fence = logicalDevice->createFence(video::IGPUFence::ECF_UNSIGNALED);
-                        tferCmdBuf->begin(0u); // TODO some one time submit bit or something
+                        tferCmdBuf->begin(IGPUCommandBuffer::EU_NONE); // TODO some one time submit bit or something
                         {
                             auto ppHandler = utilities->getDefaultPropertyPoolHandler();
                             asset::SBufferBinding<video::IGPUBuffer> scratch;
@@ -763,7 +763,7 @@ class LoDSystemApp : public ApplicationBase
 
             //
             commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-            commandBuffer->begin(0);
+            commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
             // late latch input
             const auto nextPresentationTimestamp = oracle.acquireNextImage(swapchain.get(), imageAcquire[resourceIx].get(), nullptr, &acquiredNextFBO);

--- a/examples_tests/12.glTF/main.cpp
+++ b/examples_tests/12.glTF/main.cpp
@@ -204,7 +204,7 @@ class GLTFApp : public ApplicationBase
 			{
 				xferFence = logicalDevice->createFence(static_cast<nbl::video::IGPUFence::E_CREATE_FLAGS>(0));
 				logicalDevice->createCommandBuffers(commandPools[CommonAPI::InitOutput::EQT_TRANSFER_UP].get(),nbl::video::IGPUCommandBuffer::EL_PRIMARY,1u,&xferCmdbuf);
-				xferCmdbuf->begin(0);
+				xferCmdbuf->begin(IGPUCommandBuffer::EU_NONE);
 			}
 			auto xferQueue = logicalDevice->getQueue(xferCmdbuf->getQueueFamilyIndex(),0u);
 			asset::SBufferBinding<video::IGPUBuffer> xferScratch;
@@ -795,7 +795,7 @@ class GLTFApp : public ApplicationBase
 				fence = logicalDevice->createFence(static_cast<video::IGPUFence::E_CREATE_FLAGS>(0));
 
 			commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-			commandBuffer->begin(0);
+			commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 			const auto nextPresentationTimestamp = oracle.acquireNextImage(swapchain.get(), imageAcquire[resourceIx].get(), nullptr, &acquiredNextFBO);
 

--- a/examples_tests/13.EmptyExample/main.cpp
+++ b/examples_tests/13.EmptyExample/main.cpp
@@ -533,7 +533,7 @@ Choose Graphics API:
 		else
 			fence = device->createFence(static_cast<video::IGPUFence::E_CREATE_FLAGS>(0));
 
-		commandBuffer->begin(0u);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 		swapchain->acquireNextImage(MAX_TIMEOUT, m_imageAcquire[m_resourceIx].get(), nullptr, &m_acquiredNextFBO);
 

--- a/examples_tests/16.OrderIndependentTransparency/main.cpp
+++ b/examples_tests/16.OrderIndependentTransparency/main.cpp
@@ -524,7 +524,7 @@ public:
         const auto& viewProjectionMatrix = camera.getConcatenatedMatrix();
 
         commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-        commandBuffer->begin(0);
+        commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
         asset::SViewport viewport;
         viewport.minDepth = 1.f;

--- a/examples_tests/17.SimpleBulletIntegration/main.cpp
+++ b/examples_tests/17.SimpleBulletIntegration/main.cpp
@@ -775,7 +775,7 @@ public:
 			fence = logicalDevice->createFence(static_cast<video::IGPUFence::E_CREATE_FLAGS>(0));
 
 		// safe to proceed
-		cb->begin(0);
+		cb->begin(IGPUCommandBuffer::EU_NONE);
 
 		// acquire image 
 		uint32_t imgnum = 0u;

--- a/examples_tests/18.MitsubaLoader/main.cpp
+++ b/examples_tests/18.MitsubaLoader/main.cpp
@@ -958,7 +958,7 @@ public:
 		const auto& viewProjectionMatrix = camera.getConcatenatedMatrix();
 		
 		commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-		commandBuffer->begin(0);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 		
 		asset::SViewport viewport;
 		viewport.minDepth = 1.f;
@@ -1720,7 +1720,7 @@ public:
 //		const auto& viewProjectionMatrix = camera.getConcatenatedMatrix();
 //
 //		commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-//		commandBuffer->begin(0);
+//		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 //
 //		asset::SViewport viewport;
 //		viewport.minDepth = 1.f;

--- a/examples_tests/20.Megatexture/main.cpp
+++ b/examples_tests/20.Megatexture/main.cpp
@@ -709,7 +709,7 @@ APP_CONSTRUCTOR(MegaTextureApp)
         auto commandBuffer = commandBuffers[0];
 
         commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-        commandBuffer->begin(0);
+        commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
         asset::SViewport viewport;
         viewport.minDepth = 1.f;

--- a/examples_tests/21.DynamicTextureIndexing/main.cpp
+++ b/examples_tests/21.DynamicTextureIndexing/main.cpp
@@ -563,7 +563,7 @@ public:
         const auto& viewProjectionMatrix = camera.getConcatenatedMatrix();
 
         commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-        commandBuffer->begin(0);
+        commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
         asset::SViewport viewport;
         viewport.minDepth = 1.f;

--- a/examples_tests/27.PLYSTLDemo/main.cpp
+++ b/examples_tests/27.PLYSTLDemo/main.cpp
@@ -460,7 +460,7 @@ APP_CONSTRUCTOR(PLYSTLDemo)
 		const auto& viewProjectionMatrix = camera.getConcatenatedMatrix();
 
 		commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-		commandBuffer->begin(0);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 		asset::SViewport viewport;
 		viewport.minDepth = 1.f;

--- a/examples_tests/29.SpecializationConstants/main.cpp
+++ b/examples_tests/29.SpecializationConstants/main.cpp
@@ -430,7 +430,7 @@ public:
 		}
 
 		// safe to proceed
-		cb->begin(0);
+		cb->begin(IGPUCommandBuffer::EU_NONE);
 
 		{
 			auto time = std::chrono::high_resolution_clock::now();

--- a/examples_tests/33.Draw3DLine/main.cpp
+++ b/examples_tests/33.Draw3DLine/main.cpp
@@ -223,7 +223,7 @@ public:
 		else
 			fence = device->createFence(static_cast<video::IGPUFence::E_CREATE_FLAGS>(0));
 
-		cb->begin(0);
+		cb->begin(IGPUCommandBuffer::EU_NONE);
 
 		asset::SViewport vp;
 		vp.minDepth = 1.f;

--- a/examples_tests/35.GeometryCreator/main.cpp
+++ b/examples_tests/35.GeometryCreator/main.cpp
@@ -533,7 +533,7 @@ public:
 		const auto& viewProjectionMatrix = m_camera->getConcatenatedMatrix();
 
 		commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-		commandBuffer->begin(0);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 		asset::SViewport viewport;
 		viewport.minDepth = 1.f;

--- a/examples_tests/42.FragmentShaderPathTracer/main.cpp
+++ b/examples_tests/42.FragmentShaderPathTracer/main.cpp
@@ -485,7 +485,7 @@ int main()
 		const auto viewProjectionMatrix = cam.getConcatenatedMatrix();
 				
 		// safe to proceed
-		cb->begin(0);
+		cb->begin(IGPUCommandBuffer::EU_NONE);
 
 		// renderpass 
 		uint32_t imgnum = 0u;

--- a/examples_tests/47.DerivMapTest/main.cpp
+++ b/examples_tests/47.DerivMapTest/main.cpp
@@ -380,7 +380,7 @@ public:
 				break;
 
 			commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-			commandBuffer->begin(0);
+			commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 			asset::SViewport viewport;
 			viewport.minDepth = 1.f;

--- a/examples_tests/48.ArithmeticUnitTest/main.cpp
+++ b/examples_tests/48.ArithmeticUnitTest/main.cpp
@@ -305,7 +305,7 @@ public:
 	void onAppInitialized_impl() override
 	{
 		CommonAPI::InitOutput initOutput;
-		CommonAPI::InitWithNoExt(initOutput, video::EAT_OPENGL, "Subgroup Arithmetic Test");
+		CommonAPI::InitWithNoExt(initOutput, video::EAT_VULKAN, "Subgroup Arithmetic Test");
 		gl = std::move(initOutput.apiConnection);
 		gpuPhysicalDevice = std::move(initOutput.physicalDevice);
 		logicalDevice = std::move(initOutput.logicalDevice);

--- a/examples_tests/50.NewAPITest/main.cpp
+++ b/examples_tests/50.NewAPITest/main.cpp
@@ -404,7 +404,7 @@ Choose Graphics API:
 		auto& cb = cmdbuf[i];
 		auto& fb = fbo[i];
 
-		cb->begin(0);
+		cb->begin(IGPUCommandBuffer::EU_NONE);
 		
 		const video::IGPUBuffer* buf = buffer.get();
 		size_t offset = 0u;

--- a/examples_tests/53.ComputeShaders/main.cpp
+++ b/examples_tests/53.ComputeShaders/main.cpp
@@ -572,7 +572,7 @@ APP_CONSTRUCTOR(MeshLoadersApp)
 
 		auto& commandBuffer = commandBuffers[0];
 		commandBuffer->reset(nbl::video::IGPUCommandBuffer::ERF_RELEASE_RESOURCES_BIT);
-		commandBuffer->begin(0);
+		commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
 		asset::SViewport viewport;
 		viewport.minDepth = 1.f;

--- a/examples_tests/54.Transformations/main.cpp
+++ b/examples_tests/54.Transformations/main.cpp
@@ -438,7 +438,7 @@ class TransformationApp : public ApplicationBase
 						ttm->setupTransfers(req, transfers);
 					}
 
-					cmdbuf_nodes->begin(0);
+					cmdbuf_nodes->begin(IGPUCommandBuffer::EU_NONE);
 					utils->getDefaultPropertyPoolHandler()->transferProperties(
 						cmdbuf_nodes.get(), fence_nodes.get(), scratch, { 0ull,tmp_node_buf },
 						transfers, transfers + scene::ITransformTreeManager::TransferCount, initOutput.logger.get()
@@ -648,7 +648,7 @@ class TransformationApp : public ApplicationBase
 			timestamp++;
 
 			// safe to proceed
-			cb->begin(0);
+			cb->begin(IGPUCommandBuffer::EU_NONE);
 
 			// we don't wait on anything because we do everything on the same queue
 			uint32_t waitSemaphoreCount = 0u;

--- a/examples_tests/55.RGB18E7S3/main.cpp
+++ b/examples_tests/55.RGB18E7S3/main.cpp
@@ -187,7 +187,7 @@ int main()
     auto gpuFence = logicalDevice->createFence(static_cast<video::IGPUFence::E_CREATE_FLAGS>(0));
     {
 
-        commandBuffer->begin(0);
+        commandBuffer->begin(IGPUCommandBuffer::EU_NONE);
 
         commandBuffer->bindComputePipeline(gpuComputePipeline.get());
         commandBuffer->bindDescriptorSets(asset::EPBP_COMPUTE, gpuComputePipeline->getLayout(), 0, 1, &gpuCDescriptorSet.get());

--- a/examples_tests/56.RayQuery/main.cpp
+++ b/examples_tests/56.RayQuery/main.cpp
@@ -945,7 +945,7 @@ public:
 		const auto viewProjectionMatrix = cam.getConcatenatedMatrix();
 				
 		// safe to proceed
-		cb->begin(0);
+		cb->begin(IGPUCommandBuffer::EU_NONE);
 
 		// renderpass 
 		swapchain->acquireNextImage(MAX_TIMEOUT,imageAcquire[m_resourceIx].get(),nullptr,&m_acquiredNextFBO);

--- a/examples_tests/57.AndroidSample/main.cpp
+++ b/examples_tests/57.AndroidSample/main.cpp
@@ -413,7 +413,7 @@ void main()
 			auto& cb = cmdbuf[i];
 			auto& fb = fbo[i];
 
-			cb->begin(0);
+			cb->begin(IGPUCommandBuffer::EU_NONE);
 
 			asset::SViewport vp;
 			vp.minDepth = 1.f;

--- a/include/nbl/asset/ICommandBuffer.h
+++ b/include/nbl/asset/ICommandBuffer.h
@@ -113,8 +113,9 @@ protected:
 public:
     _NBL_STATIC_INLINE_CONSTEXPR size_t MAX_PUSH_CONSTANT_BYTESIZE = 128u;
 
-    enum E_RESET_FLAGS : uint32_t
+    enum E_RESET_FLAGS : uint8_t
     {
+        ERF_NONE = 0x00,
         ERF_RELEASE_RESOURCES_BIT = 0x01
     };
 
@@ -135,7 +136,7 @@ public:
         - ES_INVALID
             -> After submission for resettable command buffers.
     */
-    enum E_STATE : uint32_t
+    enum E_STATE : uint8_t
     {
         ES_INITIAL,
         ES_RECORDING,
@@ -144,14 +145,15 @@ public:
         ES_INVALID
     };
 
-    enum E_USAGE : uint32_t
+    enum E_USAGE : uint8_t
     {
+        EU_NONE = 0x00,
         EU_ONE_TIME_SUBMIT_BIT = 0x01,
         EU_RENDER_PASS_CONTINUE_BIT = 0x02,
         EU_SIMULTANEOUS_USE_BIT = 0x04
     };
 
-    enum E_LEVEL : uint32_t
+    enum E_LEVEL : uint8_t
     {
         EL_PRIMARY = 0u,
         EL_SECONDARY
@@ -205,12 +207,13 @@ public:
 
     E_STATE getState() const { return m_state; }
 
+    core::bitflag<E_USAGE> getRecordingFlags() const { return m_recordingFlags; } // TODO(Erfan): maybe store m_recordingFlags as 
+
     E_LEVEL getLevel() const { return m_level; }
 
     // hm now i think having begin(), reset() and end() as command buffer API is a little weird
 
-    //! `_flags` takes bits from E_USAGE
-    virtual bool begin(uint32_t _flags)
+    virtual bool begin(core::bitflag<E_USAGE> _flags)
     {
         if(m_state == ES_RECORDING)
         {
@@ -222,8 +225,7 @@ public:
         return true;
     }
    
-    //! `_flags` takes bits from E_RESET_FLAGS
-    virtual bool reset(uint32_t _flags)
+    virtual bool reset(core::bitflag<E_RESET_FLAGS> _flags)
     {
         m_state = ES_INITIAL;
         return true;
@@ -365,7 +367,7 @@ protected:
 
     E_LEVEL m_level;
     // Flags from E_USAGE
-    uint32_t m_recordingFlags = 0u;
+    core::bitflag<E_USAGE> m_recordingFlags = E_USAGE::EU_NONE;
     E_STATE m_state = ES_INITIAL;
     //future
     uint32_t m_deviceMask = ~0u;

--- a/include/nbl/video/IGPUCommandBuffer.h
+++ b/include/nbl/video/IGPUCommandBuffer.h
@@ -67,7 +67,7 @@ public:
         return false;
     }
 
-    virtual bool begin(uint32_t _flags, const SInheritanceInfo* inheritanceInfo = nullptr)
+    virtual bool begin(core::bitflag<E_USAGE> _flags, const SInheritanceInfo* inheritanceInfo = nullptr)
     {
         if (!isResettable())
         {
@@ -90,7 +90,7 @@ public:
         return base_t::begin(_flags);
     }
 
-    virtual bool reset(uint32_t _flags)
+    virtual bool reset(core::bitflag<E_RESET_FLAGS> _flags)
     {
         if (!canReset())
         {

--- a/include/nbl/video/utilities/IGPUObjectFromAssetConverter.h
+++ b/include/nbl/video/utilities/IGPUObjectFromAssetConverter.h
@@ -1984,8 +1984,9 @@ auto IGPUObjectFromAssetConverter::create(const asset::ICPUAccelerationStructure
         auto gpubuf = _params.device->createBuffer(gpuBufParams);
         auto mreqs = gpubuf->getMemoryReqs();
         mreqs.memoryTypeBits &= _params.device->getPhysicalDevice()->getDeviceLocalMemoryTypeBits();
-        auto gpubufMem = _params.device->allocate(mreqs, gpubuf.get());
-            
+        auto gpubufMem = _params.device->allocate(mreqs, gpubuf.get(), IDeviceMemoryAllocation::EMAF_DEVICE_ADDRESS_BIT);
+        assert(gpubufMem.isValid());
+
         // Create GPUAccelerationStructure with that buffer
         video::IGPUAccelerationStructure::SCreationParams creatationParams = {};
         creatationParams.bufferRange.buffer = gpubuf;
@@ -2231,7 +2232,7 @@ auto IGPUObjectFromAssetConverter::create(const asset::ICPUAccelerationStructure
             auto gpuScratchBuf = _params.device->createBuffer(gpuScratchBufParams);
             auto mreqs = gpuScratchBuf->getMemoryReqs();
             mreqs.memoryTypeBits &= _params.device->getPhysicalDevice()->getDeviceLocalMemoryTypeBits();
-            auto gpuScratchBufMem = _params.device->allocate(mreqs, gpuScratchBuf.get());
+            auto gpuScratchBufMem = _params.device->allocate(mreqs, gpuScratchBuf.get(), IDeviceMemoryAllocation::EMAF_DEVICE_ADDRESS_BIT);
 
 
             for (ptrdiff_t i = 0u; i < toCreateAndBuild.size(); ++i)

--- a/include/nbl/video/utilities/IGPUVirtualTexture.h
+++ b/include/nbl/video/utilities/IGPUVirtualTexture.h
@@ -30,7 +30,7 @@ class IGPUVirtualTexture final : public asset::IVirtualTexture<IGPUImageView, IG
             assert(gpuCommandBuffer);
             // buffer should hold onto pool with refcounted backlink
         }
-        gpuCommandBuffer->begin(0u);
+        gpuCommandBuffer->begin(IGPUCommandBuffer::EU_NONE);
         return gpuCommandBuffer;
     }
     static inline core::smart_refctd_ptr<IGPUImage> createGPUImageFromCPU(

--- a/include/nbl/video/utilities/IUtilities.h
+++ b/include/nbl/video/utilities/IUtilities.h
@@ -358,6 +358,7 @@ class IUtilities : public core::IReferenceCounted
             auto* cmdpool = cmdbuf->getPool();
             assert(cmdbuf->isResettable());
             assert(cmdpool->getQueueFamilyIndex() == queue->getFamilyIndex());
+            assert(cmdbuf->getRecordingFlags().hasFlags(IGPUCommandBuffer::EU_ONE_TIME_SUBMIT_BIT));
 
             // no pipeline barriers necessary because write and optional flush happens before submit, and memory allocation is reclaimed after fence signal
             for (size_t uploadedSize = 0ull; uploadedSize < bufferRange.size;)

--- a/src/nbl/video/COpenGLCommandBuffer.cpp
+++ b/src/nbl/video/COpenGLCommandBuffer.cpp
@@ -110,7 +110,7 @@ COpenGLCommandBuffer::~COpenGLCommandBuffer()
         }
     }
 
-    bool COpenGLCommandBuffer::reset(uint32_t _flags)
+    bool COpenGLCommandBuffer::reset(core::bitflag<E_RESET_FLAGS> _flags)
     {
         if (!IGPUCommandBuffer::canReset())
             return false;

--- a/src/nbl/video/COpenGLCommandBuffer.h
+++ b/src/nbl/video/COpenGLCommandBuffer.h
@@ -542,13 +542,13 @@ public:
 
     COpenGLCommandBuffer(core::smart_refctd_ptr<const ILogicalDevice>&& dev, E_LEVEL lvl, core::smart_refctd_ptr<IGPUCommandPool>&& _cmdpool, system::logger_opt_smart_ptr&& logger, const COpenGLFeatureMap* _features);
 
-    inline bool begin(uint32_t _flags) override final
+    inline bool begin(core::bitflag<E_USAGE> _flags) override final
     {
-        reset(_flags);
+        reset(E_RESET_FLAGS::ERF_RELEASE_RESOURCES_BIT);
         return IGPUCommandBuffer::begin(_flags);
     }
     
-    inline bool begin(uint32_t _flags, const SInheritanceInfo* inheritanceInfo = nullptr) override final
+    inline bool begin(core::bitflag<E_USAGE> _flags, const SInheritanceInfo* inheritanceInfo = nullptr) override final
     {
         return IGPUCommandBuffer::begin(_flags, inheritanceInfo);
     }
@@ -558,7 +558,7 @@ public:
         assert(queriesActive.value == 0u); // No Queries should be active when command buffer ends
         return IGPUCommandBuffer::end();
     }
-    bool reset(uint32_t _flags) override final;
+    bool reset(core::bitflag<E_RESET_FLAGS> _flags) override final;
 
 
     bool bindIndexBuffer(const buffer_t* buffer, size_t offset, asset::E_INDEX_TYPE indexType) override

--- a/src/nbl/video/CVulkanCommandBuffer.h
+++ b/src/nbl/video/CVulkanCommandBuffer.h
@@ -39,11 +39,11 @@ public:
         freeSpaceInCmdPool();
     }
 
-    bool begin(uint32_t recordingFlags, const SInheritanceInfo* inheritanceInfo=nullptr) override
+    bool begin(core::bitflag<E_USAGE> recordingFlags, const SInheritanceInfo* inheritanceInfo=nullptr) override
     {
         VkCommandBufferBeginInfo beginInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO };
         beginInfo.pNext = nullptr; // pNext must be NULL or a pointer to a valid instance of VkDeviceGroupCommandBufferBeginInfo
-        beginInfo.flags = static_cast<VkCommandBufferUsageFlags>(recordingFlags);
+        beginInfo.flags = static_cast<VkCommandBufferUsageFlags>(recordingFlags.value);
 
         VkCommandBufferInheritanceInfo vk_inheritanceInfo = { VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO };
         if (inheritanceInfo)
@@ -104,7 +104,7 @@ public:
         }
     }
 
-    bool reset(uint32_t _flags) override
+    bool reset(core::bitflag<E_RESET_FLAGS> _flags) override
     {
         if(!IGPUCommandBuffer::canReset())
             return false;
@@ -113,7 +113,7 @@ public:
 
         const auto* vk = static_cast<const CVulkanLogicalDevice*>(getOriginDevice())->getFunctionTable();
 
-        if (vk->vk.vkResetCommandBuffer(m_cmdbuf, static_cast<VkCommandBufferResetFlags>(_flags)) == VK_SUCCESS)
+        if (vk->vk.vkResetCommandBuffer(m_cmdbuf, static_cast<VkCommandBufferResetFlags>(_flags.value)) == VK_SUCCESS)
         {
             return IGPUCommandBuffer::reset(_flags);
         }

--- a/src/nbl/video/CVulkanPhysicalDevice.h
+++ b/src/nbl/video/CVulkanPhysicalDevice.h
@@ -113,7 +113,7 @@ public:
                 m_properties.limits.spirvVersion = asset::IGLSLCompiler::ESV_1_5;
                 break;
             case 3:
-                m_properties.limits.spirvVersion = asset::IGLSLCompiler::ESV_1_6;
+                m_properties.limits.spirvVersion = asset::IGLSLCompiler::ESV_1_5; //TODO(Erfan): Change to ESV_1_6 when we updated our glsl compiler submodules
                 break;
             default:
                 _NBL_DEBUG_BREAK_IF("Invalid Vulkan minor version!");

--- a/src/nbl/video/utilities/IUtilities.cpp
+++ b/src/nbl/video/utilities/IUtilities.cpp
@@ -15,7 +15,8 @@ void IUtilities::updateImageViaStagingBuffer(
     auto* cmdpool = cmdbuf->getPool();
     assert(cmdbuf->isResettable());
     assert(cmdpool->getQueueFamilyIndex()==queue->getFamilyIndex());
-            
+    assert(cmdbuf->getRecordingFlags().hasFlags(IGPUCommandBuffer::EU_ONE_TIME_SUBMIT_BIT));
+
     auto texelBlockInfo = asset::TexelBlockInfo(dstImage->getCreationParameters().format);
     auto texelBlockDim = texelBlockInfo.getDimension();
     auto queueFamProps = m_device->getPhysicalDevice()->getQueueFamilyProperties()[0];


### PR DESCRIPTION
* Improving Feature/Extension Selection and Report API
* Format Promotion and Image Upload Utility Improvements
* Maintenance and general plumbing

## Examples
- [ ] Finalize Porting Example 0.ImportanceSampling
## Fixes
- [ ] Screenshot Changes
  - [ ] wait semaphore (https://github.com/Devsh-Graphics-Programming/Nabla/pull/219#discussion_r800543586)
  - [ ] add convert filter
  - [ ] add flip image option
  - [ ] dst access mask (https://github.com/Devsh-Graphics-Programming/Nabla/pull/219#discussion_r800546866)
- [ ] freeCommandBuffers_impl (see [this](https://github.com/Devsh-Graphics-Programming/Nabla/issues/305))
- [ ] drawParameters extention and fix for Vulkan and GLES (https://discord.com/channels/593902898015109131/932586232591024128/934485710193459251)
- [ ] Improve Features Selection API and Report (link to issue)
- [ ] CGLTF DerivativeMap normalization factor and builtin shader changes (consider normalization + push_constants in a nice struct)
- [ ] Const-Correctness of IGPURenderpassIndependentPipeline constructor parameters
- [ ] Image Upload Utility
  - [ ] Convert to Format and Copy Filter instead of manual
  - [ ] Improve code by using an Iterator that gives you the next region to copy based on available memory
  - [ ] Utility for calculating image data size in Asset namespace + other functions that may be useful
- [ ] Format Promotion (link to issue)
- [ ] OpenGLES Extensions that allow more formats
  - https://discord.com/channels/593902898015109131/942802829918232576/942810567624757288
- [x]  Assert in updateBufferRangeViaStagingBuffer that the commandbuffer was begun with EU_ONE_TIME_SUBMIT_BIT
## Features and Extension API

- [ ] LogicalDevice function to query Enabled Features/Extension 
- [ ] move `getExtraGLSLDefines()` to ILogicalDevice and Implement for Vulkan
- [ ] https://discord.com/channels/593902898015109131/936526907648925706/972634976422076476

Edits after Buffer API Changes:
- [ ] Fix Ex48 on Vulkan (use utilities downstreaming buffer to download data instead of multiple huge buffers)

## Acceleration Structures
- [ ] Compaction Example and in AssetConverter
- [ ] Use bitflags for accelerationStructure flags now

## old tasks, taken by others
- [ ] getSizedOpenGLFormatFromOurFormat -> cache formats, and implement format feature functions for GL
  - (https://github.com/Devsh-Graphics-Programming/Nabla/pull/160#discussion_r801454717)
  - Swapchain colorformat + colospace + oetf reporting for GL backends