### PR TITLE
Add nbl::ui window APIs for win32

### DIFF
--- a/include/nbl/ui/CWindowWin32.h
+++ b/include/nbl/ui/CWindowWin32.h
@@ -25,6 +25,8 @@ public:
 
 	inline const native_handle_t& getNativeHandle() const override { return m_native; }
 	void setCaption(const std::string_view& caption) override;
+	virtual IWindowManager* getManager() override;
+
 	~CWindowWin32() override;
 private:
 	inline CWindowWin32(CWindowManagerWin32* winManager, core::smart_refctd_ptr<system::ISystem>&& sys, SCreationParams&& params);

--- a/include/nbl/ui/IWindow.h
+++ b/include/nbl/ui/IWindow.h
@@ -13,6 +13,7 @@
 namespace nbl::ui
 {
 
+class IWindowManager;
 class ICursorControl;
 
 class IWindow : public core::IReferenceCounted
@@ -33,6 +34,9 @@ class IWindow : public core::IReferenceCounted
             //! Indicates whether mouse is hovering over the window even if the window is not active
             ECF_MOUSE_FOCUS = 1u << 8,
             ECF_ALWAYS_ON_TOP = 1u << 9,
+            //! Mobile platforms can have a window that rotates (landscape vs vertical)
+            ECF_CAN_ROTATE = 1u << 10,
+            ECF_LANDSCAPE_ORIENTATION = 1u << 11,
 
             ECF_NONE = 0
         };
@@ -172,16 +176,18 @@ class IWindow : public core::IReferenceCounted
         };
         friend struct IEventCallback;
 
-        inline bool isFullscreen()      { return (m_flags.value & ECF_FULLSCREEN); }
-        inline bool isHidden()          { return (m_flags.value & ECF_HIDDEN); }
-        inline bool isBorderless()      { return (m_flags.value & ECF_BORDERLESS); }
-        inline bool isResizable()       { return (m_flags.value & ECF_RESIZABLE); }
-        inline bool isMinimized()       { return (m_flags.value & ECF_MINIMIZED); }
-        inline bool isMaximized()       { return (m_flags.value & ECF_MAXIMIZED); }
-        inline bool hasMouseCaptured()  { return (m_flags.value & ECF_MOUSE_CAPTURE); }
-        inline bool hasInputFocus()     { return (m_flags.value & ECF_INPUT_FOCUS); }
-        inline bool hasMouseFocus()     { return (m_flags.value & ECF_MOUSE_FOCUS); }
-        inline bool isAlwaysOnTop()     { return (m_flags.value & ECF_ALWAYS_ON_TOP); }
+        inline bool isFullscreen()        { return (m_flags.value & ECF_FULLSCREEN); }
+        inline bool isHidden()            { return (m_flags.value & ECF_HIDDEN); }
+        inline bool isBorderless()        { return (m_flags.value & ECF_BORDERLESS); }
+        inline bool isResizable()         { return (m_flags.value & ECF_RESIZABLE); }
+        inline bool isMinimized()         { return (m_flags.value & ECF_MINIMIZED); }
+        inline bool isMaximized()         { return (m_flags.value & ECF_MAXIMIZED); }
+        inline bool hasMouseCaptured()    { return (m_flags.value & ECF_MOUSE_CAPTURE); }
+        inline bool hasInputFocus()       { return (m_flags.value & ECF_INPUT_FOCUS); }
+        inline bool hasMouseFocus()       { return (m_flags.value & ECF_MOUSE_FOCUS); }
+        inline bool isAlwaysOnTop()       { return (m_flags.value & ECF_ALWAYS_ON_TOP); }
+        inline bool canRotate()           { return (m_flags.value & ECF_CAN_ROTATE); }
+        inline bool isRotationLandscape() { return (m_flags.value & ECF_LANDSCAPE_ORIENTATION); }
 
         inline uint32_t getWidth() const { return m_width; }
         inline uint32_t getHeight() const { return m_height; }
@@ -190,6 +196,7 @@ class IWindow : public core::IReferenceCounted
 
         NBL_API2 virtual IClipboardManager* getClipboardManager() = 0;
         NBL_API2 virtual ICursorControl* getCursorControl() = 0;
+        NBL_API2 virtual IWindowManager* getManager() = 0;
 
         inline IEventCallback* getEventCallback() const { return m_cb.get(); }
 

--- a/include/nbl/ui/IWindowManager.h
+++ b/include/nbl/ui/IWindowManager.h
@@ -22,6 +22,74 @@ class NBL_API2 IWindowManager : public core::IReferenceCounted
 		virtual core::smart_refctd_ptr<IWindow> createWindow(IWindow::SCreationParams&& creationParams) = 0;
 		virtual SDisplayInfo getPrimaryDisplayInfo() const = 0;
 
+		NBL_API2 virtual bool setWindowSize_impl(IWindow* window, uint32_t width, uint32_t height) = 0;
+		NBL_API2 virtual bool setWindowPosition_impl(IWindow* window, int32_t x, int32_t y) = 0;
+		NBL_API2 virtual bool setWindowRotation_impl(IWindow* window, bool landscape) = 0;
+		NBL_API2 virtual bool setWindowVisible_impl(IWindow* window, bool visible) = 0;
+		NBL_API2 virtual bool setWindowMaximized_impl(IWindow* window, bool maximized) = 0;
+
+		inline bool setWindowSize(IWindow* window, const uint32_t width, const uint32_t height)
+		{
+			auto cb = window->getEventCallback();
+			if (window->getManager() != this || !window->isResizable() || cb && !cb->onWindowResized(window, width, height))
+				return false;
+
+			return setWindowSize_impl(window, width, height);
+		}
+
+		inline bool setWindowPosition(IWindow* window, const int32_t x, const int32_t y)
+		{
+			auto cb = window->getEventCallback();
+			if (window->getManager() != this || !window->isResizable() || cb && !cb->onWindowMoved(window, x, y))
+				return false;
+
+			return setWindowPosition_impl(window, x, y);
+		}
+
+		inline bool setWindowRotation(IWindow* window, const bool landscape)
+		{
+			auto cb = window->getEventCallback();
+			if (window->getManager() != this || !window->canRotate() || landscape == window->isRotationLandscape() || cb && !cb->onWindowRotated(window))
+				return false;
+
+			return setWindowRotation_impl(window, landscape);
+		}
+
+		inline bool show(IWindow* window)
+		{
+			auto cb = window->getEventCallback();
+			if (window->getManager() != this || !window->isResizable() || !window->isHidden() || cb && !cb->onWindowShown(window))
+				return false;
+
+			return setWindowVisible_impl(window, true);
+		}
+
+		inline bool hide(IWindow* window)
+		{
+			auto cb = window->getEventCallback();
+			if (window->getManager() != this || !window->isResizable() || window->isHidden() || cb && !cb->onWindowHidden(window))
+				return false;
+
+			return setWindowVisible_impl(window, false);
+		}
+
+		inline bool maximize(IWindow* window)
+		{
+			auto cb = window->getEventCallback();
+			if (window->getManager() != this || !window->isResizable() || window->isMaximized() || cb && !cb->onWindowMaximized(window))
+				return false;
+
+			return setWindowMaximized_impl(window, true);
+		}
+
+		inline bool minimize(IWindow* window)
+		{
+			auto cb = window->getEventCallback();
+			if (window->getManager() != this || !window->isResizable() || window->isMinimized() || cb && !cb->onWindowMinimized(window))
+				return false;
+
+			return setWindowMaximized_impl(window, false);
+		}
 	private:
 		virtual void destroyWindow(IWindow* wnd) = 0;
 

--- a/src/nbl/ui/CWindowWin32.cpp
+++ b/src/nbl/ui/CWindowWin32.cpp
@@ -32,6 +32,11 @@ namespace nbl::ui
 		m_windowManager->destroyWindow(this);
 	}
 
+	IWindowManager* CWindowWin32::getManager()
+	{
+		return m_windowManager.get();
+	}
+
 	IClipboardManager* CWindowWin32::getClipboardManager()
 	{
 		return m_clipboardManager.get();


### PR DESCRIPTION
## Description
Adds programatic window resizing (+ maximize and minimize), positioning, hiding and shwoing for win32.

See also: #379 

## Testing 
All the methods were tested with the hello world example.

## TODO list:
- [ ] Android implementations
- [ ] Other resizing work

<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
