### PR TITLE
Fix issue with SFormatImageUsage ctor

### DIFF
--- a/include/nbl/video/IPhysicalDevice.h
+++ b/include/nbl/video/IPhysicalDevice.h
@@ -358,6 +358,7 @@ class NBL_API2 IPhysicalDevice : public core::Interface, public core::Unmovable
 
             SFormatImageUsage(core::bitflag<asset::IImage::E_USAGE_FLAGS> usages)
                 : isInitialized(1), 
+                log2MaxSamples(0),
                 sampledImage(usages.hasFlags(asset::IImage::EUF_SAMPLED_BIT)),
                 storageImage(usages.hasFlags(asset::IImage::EUF_STORAGE_BIT)),
                 transferSrc(usages.hasFlags(asset::IImage::EUF_TRANSFER_SRC_BIT)),
@@ -522,7 +523,7 @@ class NBL_API2 IPhysicalDevice : public core::Interface, public core::Unmovable
         struct FormatPromotionRequest
         {
             asset::E_FORMAT originalFormat = asset::EF_UNKNOWN;
-            FORMAT_USAGE usages;
+            FORMAT_USAGE usages = FORMAT_USAGE(0);
 
             struct hash
             {


### PR DESCRIPTION
## Description
There was UB with format promotion due to uninitialized fields.

## Testing 
Example 06's promotion of the depth format.

## TODO list:

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
