### PR TITLE
Update setWindowSize & other window manager functions to ignore callback

### DIFF
--- a/include/nbl/ui/CWindowManagerWin32.h
+++ b/include/nbl/ui/CWindowManagerWin32.h
@@ -62,8 +62,22 @@ class CWindowManagerWin32 : public IWindowManager
 
 		inline bool setWindowSize_impl(IWindow* window, const uint32_t width, const uint32_t height) override
 		{
+			// Calculate real window size based on client size
+			RECT clientSize;
+			clientSize.left = 0;
+			clientSize.top = 0;
+			clientSize.right = width;
+			clientSize.bottom = height;
+
+			DWORD style = CThreadHandler::getWindowStyle(window->getFlags().value);
+			bool res = AdjustWindowRect(&clientSize, style, false);
+			assert(res);
+
+			const int32_t realWidth = clientSize.right - clientSize.left;
+			const int32_t realHeight = clientSize.bottom - clientSize.top;
+
 			auto wnd = static_cast<IWindowWin32*>(window);
-			m_windowThreadManager.setWindowSize(wnd->getNativeHandle(), width, height);
+			m_windowThreadManager.setWindowSize(wnd->getNativeHandle(), realWidth, realHeight);
 			return true;
 		}
 		inline bool setWindowPosition_impl(IWindow* window, const int32_t x, const int32_t y) override
@@ -256,6 +270,43 @@ class CWindowManagerWin32 : public IWindowManager
 				{
 				}
 
+				// TODO where should this be
+				static DWORD getWindowStyle(IWindow::E_CREATE_FLAGS flags)
+				{
+					DWORD style = WS_POPUP;
+
+					if ((flags & IWindow::ECF_FULLSCREEN) == 0)
+					{
+						if ((flags & IWindow::ECF_BORDERLESS) == 0)
+						{
+							style |= WS_BORDER;
+							style |= (WS_SYSMENU | WS_CAPTION);
+						}
+						// ? not sure about those below
+						style |= WS_CLIPCHILDREN;
+						style |= WS_CLIPSIBLINGS;
+					}
+					if (flags & IWindow::ECF_MINIMIZED)
+					{
+						style |= WS_MINIMIZE;
+					}
+					if (flags & IWindow::ECF_MAXIMIZED)
+					{
+						style |= WS_MAXIMIZE;
+					}
+					if (flags & IWindow::ECF_ALWAYS_ON_TOP)
+					{
+						style |= WS_EX_TOPMOST;
+					}
+					if ((flags & IWindow::ECF_HIDDEN) == 0)
+					{
+						style |= WS_VISIBLE;
+					}
+					style |= WS_OVERLAPPEDWINDOW;
+
+					return style;
+				}
+
 			private:
 				void waitForCompletion(SRequest& req)
 				{
@@ -313,36 +364,7 @@ class CWindowManagerWin32 : public IWindowManager
 						clientSize.right = clientSize.left + params.width;
 						clientSize.bottom = clientSize.top + params.height;
 
-						DWORD style = WS_POPUP; // TODO why popup?
-
-						if ((params.flags & CWindowWin32::ECF_FULLSCREEN) == 0)
-						{
-							if ((params.flags & CWindowWin32::ECF_BORDERLESS) == 0)
-							{
-								style |= WS_BORDER;
-								style |= (WS_SYSMENU | WS_CAPTION);
-							}
-							// ? not sure about those below
-							style |= WS_CLIPCHILDREN;
-							style |= WS_CLIPSIBLINGS;
-						}
-						if (params.flags & CWindowWin32::ECF_MINIMIZED)
-						{
-							style |= WS_MINIMIZE;
-						}
-						if (params.flags & CWindowWin32::ECF_MAXIMIZED)
-						{
-							style |= WS_MAXIMIZE;
-						}
-						if (params.flags & CWindowWin32::ECF_ALWAYS_ON_TOP)
-						{
-							style |= WS_EX_TOPMOST;
-						}
-						if ((params.flags & CWindowWin32::ECF_HIDDEN) == 0)
-						{
-							style |= WS_VISIBLE;
-						}
-						style |= WS_OVERLAPPEDWINDOW;
+						DWORD style = CThreadHandler::getWindowStyle(params.flags);
 
 						// TODO:
 						// if (hasMouseCaptured())

--- a/include/nbl/ui/CWindowManagerWin32.h
+++ b/include/nbl/ui/CWindowManagerWin32.h
@@ -69,7 +69,7 @@ class CWindowManagerWin32 : public IWindowManager
 			clientSize.right = width;
 			clientSize.bottom = height;
 
-			DWORD style = CThreadHandler::getWindowStyle(window->getFlags().value);
+			DWORD style = IWindowWin32::getWindowStyle(window->getFlags().value);
 			bool res = AdjustWindowRect(&clientSize, style, false);
 			assert(res);
 
@@ -270,43 +270,6 @@ class CWindowManagerWin32 : public IWindowManager
 				{
 				}
 
-				// TODO where should this be
-				static DWORD getWindowStyle(IWindow::E_CREATE_FLAGS flags)
-				{
-					DWORD style = WS_POPUP;
-
-					if ((flags & IWindow::ECF_FULLSCREEN) == 0)
-					{
-						if ((flags & IWindow::ECF_BORDERLESS) == 0)
-						{
-							style |= WS_BORDER;
-							style |= (WS_SYSMENU | WS_CAPTION);
-						}
-						// ? not sure about those below
-						style |= WS_CLIPCHILDREN;
-						style |= WS_CLIPSIBLINGS;
-					}
-					if (flags & IWindow::ECF_MINIMIZED)
-					{
-						style |= WS_MINIMIZE;
-					}
-					if (flags & IWindow::ECF_MAXIMIZED)
-					{
-						style |= WS_MAXIMIZE;
-					}
-					if (flags & IWindow::ECF_ALWAYS_ON_TOP)
-					{
-						style |= WS_EX_TOPMOST;
-					}
-					if ((flags & IWindow::ECF_HIDDEN) == 0)
-					{
-						style |= WS_VISIBLE;
-					}
-					style |= WS_OVERLAPPEDWINDOW;
-
-					return style;
-				}
-
 			private:
 				void waitForCompletion(SRequest& req)
 				{
@@ -364,7 +327,7 @@ class CWindowManagerWin32 : public IWindowManager
 						clientSize.right = clientSize.left + params.width;
 						clientSize.bottom = clientSize.top + params.height;
 
-						DWORD style = CThreadHandler::getWindowStyle(params.flags);
+						DWORD style = IWindowWin32::getWindowStyle(params.flags);
 
 						// TODO:
 						// if (hasMouseCaptured())

--- a/include/nbl/ui/IWindow.h
+++ b/include/nbl/ui/IWindow.h
@@ -184,6 +184,8 @@ class IWindow : public core::IReferenceCounted
         inline bool hasMouseFocus()       { return (m_flags.value & ECF_MOUSE_FOCUS); }
         inline bool isAlwaysOnTop()       { return (m_flags.value & ECF_ALWAYS_ON_TOP); }
 
+        inline core::bitflag<E_CREATE_FLAGS> getFlags() { return m_flags; }
+
         inline uint32_t getWidth() const { return m_width; }
         inline uint32_t getHeight() const { return m_height; }
         inline int32_t getX() const { return m_x; }

--- a/include/nbl/ui/IWindowManager.h
+++ b/include/nbl/ui/IWindowManager.h
@@ -31,7 +31,7 @@ class NBL_API2 IWindowManager : public core::IReferenceCounted
 		inline bool setWindowSize(IWindow* window, const uint32_t width, const uint32_t height)
 		{
 			auto cb = window->getEventCallback();
-			if (window->getManager() != this || !window->isResizable() || cb && !cb->onWindowResized(window, width, height))
+			if (window->getManager() != this || !window->isResizable())
 				return false;
 
 			return setWindowSize_impl(window, width, height);
@@ -40,7 +40,7 @@ class NBL_API2 IWindowManager : public core::IReferenceCounted
 		inline bool setWindowPosition(IWindow* window, const int32_t x, const int32_t y)
 		{
 			auto cb = window->getEventCallback();
-			if (window->getManager() != this || !window->isResizable() || cb && !cb->onWindowMoved(window, x, y))
+			if (window->getManager() != this || !window->isResizable())
 				return false;
 
 			return setWindowPosition_impl(window, x, y);
@@ -51,7 +51,7 @@ class NBL_API2 IWindowManager : public core::IReferenceCounted
 			// TODO
 			/*
 			auto cb = window->getEventCallback();
-			if (window->getManager() != this || !window->canRotate() || landscape == window->isRotationLandscape() || cb && !cb->onWindowRotated(window))
+			if (window->getManager() != this || !window->canRotate() || landscape == window->isRotationLandscape())
 				return false;
 
 			return setWindowRotation_impl(window, landscape);
@@ -62,7 +62,7 @@ class NBL_API2 IWindowManager : public core::IReferenceCounted
 		inline bool show(IWindow* window)
 		{
 			auto cb = window->getEventCallback();
-			if (window->getManager() != this || !window->isResizable() || !window->isHidden() || cb && !cb->onWindowShown(window))
+			if (window->getManager() != this || !window->isResizable() || !window->isHidden())
 				return false;
 
 			return setWindowVisible_impl(window, true);
@@ -71,7 +71,7 @@ class NBL_API2 IWindowManager : public core::IReferenceCounted
 		inline bool hide(IWindow* window)
 		{
 			auto cb = window->getEventCallback();
-			if (window->getManager() != this || !window->isResizable() || window->isHidden() || cb && !cb->onWindowHidden(window))
+			if (window->getManager() != this || !window->isResizable() || window->isHidden())
 				return false;
 
 			return setWindowVisible_impl(window, false);
@@ -80,7 +80,7 @@ class NBL_API2 IWindowManager : public core::IReferenceCounted
 		inline bool maximize(IWindow* window)
 		{
 			auto cb = window->getEventCallback();
-			if (window->getManager() != this || !window->isResizable() || window->isMaximized() || cb && !cb->onWindowMaximized(window))
+			if (window->getManager() != this || !window->isResizable() || window->isMaximized())
 				return false;
 
 			return setWindowMaximized_impl(window, true);
@@ -89,7 +89,7 @@ class NBL_API2 IWindowManager : public core::IReferenceCounted
 		inline bool minimize(IWindow* window)
 		{
 			auto cb = window->getEventCallback();
-			if (window->getManager() != this || !window->isResizable() || window->isMinimized() || cb && !cb->onWindowMinimized(window))
+			if (window->getManager() != this || !window->isResizable() || window->isMinimized())
 				return false;
 
 			return setWindowMaximized_impl(window, false);

--- a/include/nbl/ui/IWindowWin32.h
+++ b/include/nbl/ui/IWindowWin32.h
@@ -23,6 +23,42 @@ class NBL_API2 IWindowWin32 : public IWindow
         using native_handle_t = HWND;
 
         virtual const native_handle_t& getNativeHandle() const = 0;
+
+		static DWORD getWindowStyle(IWindow::E_CREATE_FLAGS flags)
+		{
+			DWORD style = WS_POPUP;
+
+			if ((flags & IWindow::ECF_FULLSCREEN) == 0)
+			{
+				if ((flags & IWindow::ECF_BORDERLESS) == 0)
+				{
+					style |= WS_BORDER;
+					style |= (WS_SYSMENU | WS_CAPTION);
+				}
+				// ? not sure about those below
+				style |= WS_CLIPCHILDREN;
+				style |= WS_CLIPSIBLINGS;
+			}
+			if (flags & IWindow::ECF_MINIMIZED)
+			{
+				style |= WS_MINIMIZE;
+			}
+			if (flags & IWindow::ECF_MAXIMIZED)
+			{
+				style |= WS_MAXIMIZE;
+			}
+			if (flags & IWindow::ECF_ALWAYS_ON_TOP)
+			{
+				style |= WS_EX_TOPMOST;
+			}
+			if ((flags & IWindow::ECF_HIDDEN) == 0)
+			{
+				style |= WS_VISIBLE;
+			}
+			style |= WS_OVERLAPPEDWINDOW;
+
+			return style;
+		}
 };
 
 }


### PR DESCRIPTION
## Description
Currently, when resizing the window using the API call (`setWindowSize`) calls the event callback, but the result is unused as it doesn't stop the resize; Then, the event callback is called again, potentially with a new size including window borders and other possible calculations from Windows.

The maximum size returned by the surface capabilities should be taken into account when recreating the swapchain, as is done in the sister PR.

Sister PR: https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/pull/19

## Testing 
Example 09 was tested to not log the resizes twice.
<!-- Explain how this change was tested. -->

## TODO list:
<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
