### PR TITLE
Material compiler v2

### DIFF
--- a/include/nbl/asset/material_compiler/v2/IR.h
+++ b/include/nbl/asset/material_compiler/v2/IR.h
@@ -1,0 +1,262 @@
+// Copyright (C) 2018-2023 - DevSH Graphics Programming Sp. z O.O.
+// This file is part of the "Nabla Engine".
+// For conditions of distribution and use, see copyright notice in nabla.h
+
+#ifndef __NBL_ASSET_MATERIAL_COMPILER_V2_IR_H_INCLUDED__
+#define __NBL_ASSET_MATERIAL_COMPILER_V2_IR_H_INCLUDED__
+
+#include "IRNode.h"
+#include <nbl/asset/ICPUImageView.h>
+#include <nbl/asset/ICPUSampler.h>
+#include <nbl/core/IReferenceCounted.h>
+#include <nbl/core/containers/refctd_dynamic_array.h>
+#include <nbl/core/math/fnvhash.h>
+
+namespace nbl::asset::material_compiler::v2::ir {
+
+// Visit the tree of nodes with specified node as root in DFS order.
+template <typename Visitor>
+NBL_FORCE_INLINE void traverse_node_tree_dfs(NodeHandle root, Visitor visitor) {
+  core::vector<NodeHandle> worklist;
+  worklist.push_back(root);
+  while (!worklist.empty()) {
+    NodeHandle cur = worklist.back();
+    worklist.pop_back();
+    visitor(cur);
+    for (OffsetToValue value_offset : cur->get_value_offsets())
+      if (cur->value(value_offset).is_node())
+        worklist.push_back(cur->value(value_offset).get_node());
+  }
+}
+
+// Traverse the tree of nodes in reverse bfs order which
+// gurantess we visit all nodes gets depended by upper level
+// nodes are visited beforehand. (kahn's algorithm)
+template <typename Visitor>
+NBL_FORCE_INLINE void traverse_node_tree_topological(NodeHandle root,
+                                                     Visitor visitor) {
+  core::queue<NodeHandle> q;
+  core::vector<NodeHandle> worklist;
+  q.push(root);
+  while (!q.empty()) {
+    NodeHandle cur = q.front();
+    q.pop();
+    for (OffsetToValue value_offset : cur->get_value_offsets())
+      if (cur->value(value_offset).is_node())
+        worklist.push_back(cur->value(value_offset).get_node());
+  }
+  while (!worklist.empty()) {
+    NodeHandle cur = worklist.back();
+    worklist.pop_back();
+    visitor(cur);
+  }
+}
+
+class NodeHandleHasher {
+public:
+  size_t operator()(const NodeHandle &key) const { return key->get_hash(); }
+};
+
+class NodeHandleComparor {
+public:
+  bool operator()(const NodeHandle &lhs, const NodeHandle &rhs) const {
+    return *lhs == *rhs;
+  }
+};
+
+using INodeCacheSet =
+    core::unordered_set<NodeHandle, NodeHandleHasher, NodeHandleComparor>;
+
+class NBL_API IRDAG : public core::IReferenceCounted {
+public:
+  IRDAG() {}
+
+  ~IRDAG() {}
+
+  INodeHash get_hash() const {
+    INodeHash hash_value = 0;
+    for (NodeHandle root : root_nodes) {
+      hash_value ^= root->get_hash();
+    }
+    return hash_value;
+  }
+
+  // Insert subdag into this DAG
+  NodeHandle insert_subdag(IRDAG &dag) {
+    assert(dag.root_nodes.size() == 1); // we must have only one root
+    INodeCacheSet cache;
+    for (NodeHandle node : nodes.get_handles()) {
+      cache.insert(node);
+    }
+    NodeHandle root = *dag.root_nodes.begin();
+    traverse_node_tree_topological(root, [&](NodeHandle cur) {
+      if (cache.count(cur))
+        return;
+      NodeHandle cloned = cur->clone(*this);
+      for (OffsetToValue value_offset : cloned->get_value_offsets()) {
+        Value &value = cloned->value(value_offset);
+        if (value.is_node()) {
+          auto it = cache.find(value.get_node());
+          assert(it != cache.end()); // node must have been visited before
+          value = Value(*it);
+        }
+        if (value.is_texture())
+          value = Value(create_texture(*value.get_texture()));
+      }
+      cache.insert(cloned);
+    });
+    return *cache.find(root);
+  }
+
+  NodeHandle clone_node(NodeHandle node) { return node->clone(*this); }
+
+  template <typename ST, typename... Args>
+  NodeHandle create_node(Args &&...args) {
+    return nodes.create<ST>(std::forward<Args>(args)...);
+  }
+
+  TextureHandle create_texture(const TextureSource &texture) {
+    auto it = texture_cache.find(texture);
+    if (it != texture_cache.end())
+      return it->second;
+    return texture_cache[texture] = textures.create<TextureSource>(
+               texture.image, texture.sampler, texture.scale);
+  }
+
+  void add_root(NodeHandle node) { root_nodes.push_back(node); }
+
+  void remove_node(NodeHandle node) { nodes.remove(node); }
+
+  const core::set<NodeHandle> &get_nodes() const { return nodes.get_handles(); }
+
+  const core::vector<NodeHandle> &get_roots() const { return root_nodes; }
+
+private:
+  template <typename T, typename MemMgr> class CHandleManager {
+  public:
+    using HandleId = Handle<T>::HandleId;
+
+    ~CHandleManager() {
+      while (!handles.empty())
+        remove(*handles.rbegin());
+    }
+
+    template <typename ST, typename... Args> Handle<T> create(Args &&...args) {
+      ST *ptr = alloc<ST>(std::forward<Args>(args)...);
+      ptrdiff_t offset = reinterpret_cast<uint8_t *>(ptr) - mem_mgr.get_base();
+      HandleId new_id = offset;
+      return Handle<T>(reinterpret_cast<uint8_t *>(mem_mgr.get_base()), new_id);
+    }
+
+    void remove(Handle<T> handle) {
+      T &obj = *handle;
+      obj.~T();
+      handles.erase(handle);
+    }
+
+    const core::set<Handle<T>> &get_handles() const { return handles; }
+
+  private:
+    template <typename ST, typename... Args> ST *alloc(Args &&...args) {
+      uint8_t *ptr = mem_mgr.alloc(sizeof(ST));
+      return new (ptr) ST(std::forward<Args>(args)...);
+    }
+
+    core::set<Handle<T>> handles;
+    MemMgr mem_mgr;
+  };
+
+  class SBackingMemManager {
+    _NBL_STATIC_INLINE_CONSTEXPR size_t INITIAL_MEM_SIZE = 1ull << 20;
+    _NBL_STATIC_INLINE_CONSTEXPR size_t MAX_MEM_SIZE = 1ull << 20;
+    _NBL_STATIC_INLINE_CONSTEXPR size_t ALIGNMENT = _NBL_SIMD_ALIGNMENT;
+
+    uint8_t *mem;
+    size_t currSz;
+    using addr_alctr_t = core::LinearAddressAllocator<uint32_t>;
+    addr_alctr_t addrAlctr;
+
+  public:
+    SBackingMemManager()
+        : mem(nullptr), currSz(INITIAL_MEM_SIZE),
+          addrAlctr(nullptr, 0u, 0u, ALIGNMENT, MAX_MEM_SIZE) {
+      mem = reinterpret_cast<uint8_t *>(_NBL_ALIGNED_MALLOC(currSz, ALIGNMENT));
+    }
+    ~SBackingMemManager() { _NBL_ALIGNED_FREE(mem); }
+
+    uint8_t *get_base() const { return mem; }
+
+    uint8_t *alloc(size_t bytes) {
+      auto addr = addrAlctr.alloc_addr(bytes, ALIGNMENT);
+      assert(addr != addr_alctr_t::invalid_address);
+      // TODO reallocation will invalidate all pointers to nodes, so...
+      // 1) never reallocate (just have reasonably big buffer for nodes)
+      // 2) make some node_handle class that will work as pointer but is based
+      // on offset instead of actual address
+      if (addr + bytes > currSz) {
+        size_t newSz = currSz << 1;
+        if (newSz > MAX_MEM_SIZE) {
+          addrAlctr.free_addr(addr, bytes);
+          return nullptr;
+        }
+
+        void *newMem = _NBL_ALIGNED_MALLOC(newSz, ALIGNMENT);
+        memcpy(newMem, mem, currSz);
+        _NBL_ALIGNED_FREE(mem);
+        mem = reinterpret_cast<uint8_t *>(newMem);
+        currSz = newSz;
+      }
+
+      return mem + addr;
+    }
+
+    uint32_t getAllocatedSize() const { return addrAlctr.get_allocated_size(); }
+
+    void freeLastAllocatedBytes(uint32_t _bytes) {
+      assert(addrAlctr.get_allocated_size() >= _bytes);
+      const uint32_t newCursor = addrAlctr.get_allocated_size() - _bytes;
+      addrAlctr.reset(newCursor);
+    }
+  };
+
+  core::vector<NodeHandle> root_nodes;
+  CHandleManager<INode, SBackingMemManager> nodes;
+  CHandleManager<TextureSource, SBackingMemManager> textures;
+  core::unordered_map<TextureSource, TextureHandle, TextureSourceHasher,
+                      TextureSourceComparor>
+      texture_cache;
+};
+
+NBL_FORCE_INLINE void dead_strip_pass(IRDAG &dag) {
+  core::set<NodeHandle> dead = dag.get_nodes();
+  for (NodeHandle root : dag.get_roots())
+    traverse_node_tree_dfs(root, [&](NodeHandle node) { dead.erase(node); });
+  for (NodeHandle node : dead)
+    dag.remove_node(node);
+}
+
+NBL_FORCE_INLINE void subexpression_elimination_pass(IRDAG &dag) {
+  INodeCacheSet cache;
+  for (NodeHandle root : dag.get_roots()) {
+    // traverse tree in topological order to properly add first known node of
+    // the same hash into cache and replace children with cached node
+    traverse_node_tree_topological(root, [&](NodeHandle cur) {
+      if (cache.count(cur))
+        return;
+      for (OffsetToValue value_offset : cur->get_value_offsets()) {
+        Value &value = cur->value(value_offset);
+        if (!value.is_node())
+          continue;
+        auto it = cache.find(value.get_node());
+        assert(it != cache.end()); // node must have been visited before
+        value = Value(*it);
+      }
+      cache.insert(cur);
+    });
+  }
+  dead_strip_pass(dag); // we can now remove unused nodes
+}
+
+} // namespace nbl::asset::material_compiler::v2::ir
+
+#endif

--- a/include/nbl/asset/material_compiler/v2/IRNode.h
+++ b/include/nbl/asset/material_compiler/v2/IRNode.h
@@ -1,0 +1,565 @@
+// Copyright (C) 2018-2023 - DevSH Graphics Programming Sp. z O.O.
+// This file is part of the "Nabla Engine".
+// For conditions of distribution and use, see copyright notice in nabla.h
+
+#ifndef __NBL_ASSET_MATERIAL_COMPILER_V2_IR_NODE_H_INCLUDED__
+#define __NBL_ASSET_MATERIAL_COMPILER_V2_IR_NODE_H_INCLUDED__
+
+#include <nbl/asset/ICPUImageView.h>
+#include <nbl/asset/ICPUSampler.h>
+#include <nbl/core/ApplyMacro.h>
+#include <nbl/core/IReferenceCounted.h>
+#include <nbl/core/containers/refctd_dynamic_array.h>
+#include <nbl/core/math/fnvhash.h>
+
+namespace nbl::asset::material_compiler::v2::ir {
+
+using vec3_t = core::vector3df_SIMD;
+
+class IRDAG;
+
+template <typename T> class Handle {
+public:
+  using HandleId = uint32_t;
+  static constexpr const HandleId null_offset =
+      std::numeric_limits<HandleId>::max();
+
+  Handle() = default;
+  explicit Handle(uint8_t *memoryBase, HandleId offset) : offset(offset) {}
+
+  operator bool() const { return offset != null_offset; }
+
+  bool operator==(const Handle &rhs) const {
+    return base == rhs.base && offset == rhs.offset;
+  }
+
+  bool operator!=(const Handle &rhs) const {
+    return base == rhs.base && offset != rhs.offset;
+  }
+
+  bool operator<(const Handle &rhs) const {
+    return base < rhs.base && offset < rhs.offset;
+  }
+
+  HandleId get_id() const { return offset; }
+
+  void reset() { uint8_t = null_offset; }
+
+  T &operator*() { return *reinterpret_cast<T *>(base + offset); }
+
+  T *operator->() { return reinterpret_cast<T *>(base + offset); }
+
+  const T &operator*() const {
+    return *reinterpret_cast<const T *>(base + offset);
+  }
+
+  const T *operator->() const {
+    return reinterpret_cast<const T *>(base + offset);
+  }
+
+private:
+  uint8_t *base{nullptr};
+  HandleId offset{null_offset};
+};
+
+struct TextureSource {
+  TextureSource() = default;
+  ~TextureSource() = default;
+  TextureSource(const core::smart_refctd_ptr<ICPUImageView> &image,
+                const core::smart_refctd_ptr<ICPUSampler> &sampler, float scale)
+      : image(image), sampler(sampler), scale(scale) {}
+  core::smart_refctd_ptr<ICPUImageView> image;
+  core::smart_refctd_ptr<ICPUSampler> sampler;
+  float scale;
+
+  uint64_t get_hash() const {
+    return core::fnv_hash(image.get()) ^ core::fnv_hash(sampler.get()) ^
+           core::fnv_hash(scale);
+  }
+  bool operator==(const TextureSource &rhs) const {
+    return image == rhs.image && sampler == rhs.sampler && scale == rhs.scale;
+  }
+};
+
+class TextureSourceHasher {
+public:
+  size_t operator()(const TextureSource &key) const { return key.get_hash(); }
+};
+
+class TextureSourceComparor {
+public:
+  bool operator()(const TextureSource &lhs, const TextureSource &rhs) const {
+    return lhs == rhs;
+  }
+};
+
+//! Type of a value in the IR
+/*!
+ * NONE: null type
+ * NODE: the result of the node
+ * OUTPUT: the final output of BSDF graph -- could be BSDF value, PDF, quotient
+ * remaindar, or AOV depending on instruction stream type VEC3: vector with 3
+ * float elements TEXTURE: handle pointing to texture
+ */
+enum class ValueType : uint8_t {
+  NONE = 0,
+  NODE,
+  OUTPUT,
+  VEC3,
+  FLOAT,
+  TEXTURE,
+};
+
+using INodeHash = uint64_t;
+
+struct INode;
+using TextureHandle = Handle<TextureSource>;
+using NodeHandle = Handle<INode>;
+
+//! Value in the IR
+/** A value is either constant or result of node.
+ */
+class Value {
+public:
+  Value() : type(ValueType::NONE) {}
+  ~Value() {}
+
+  explicit Value(NodeHandle node) : type(ValueType::NODE), node(node) {}
+  explicit Value(vec3_t value) : type(ValueType::VEC3), imm_vec3(value) {}
+  explicit Value(float value) : type(ValueType::FLOAT), imm_float(value) {}
+  explicit Value(TextureHandle value)
+      : type(ValueType::TEXTURE), texture(texture) {}
+
+  bool is_node() const { return type == ValueType::NODE; }
+  bool is_const() const { return !is_none() && !is_node(); }
+  bool is_none() const { return type == ValueType::NONE; }
+  bool is_texture() const { return type == ValueType::TEXTURE; }
+
+  vec3_t get_vec3() const {
+    assert(type == ValueType::VEC3);
+    return imm_vec3;
+  }
+  float get_float() const {
+    assert(type == ValueType::FLOAT);
+    return imm_float;
+  }
+  NodeHandle get_node() const {
+    assert(type == ValueType::NODE);
+    return node;
+  }
+  TextureHandle get_texture() const {
+    assert(type == ValueType::TEXTURE);
+    return texture;
+  }
+  // Return type of immediate or return type of node
+  ValueType get_type() const;
+  // Return the hash of the value
+  INodeHash get_hash() const;
+
+  Value(const Value &other) { std::memcpy(this, &other, sizeof(Value)); }
+  Value &operator=(const Value &other) {
+    std::memcpy(this, &other, sizeof(Value));
+    return *this;
+  }
+
+  bool operator==(const Value &other) const;
+
+private:
+  ValueType type;
+  union {
+    NodeHandle node;
+    TextureHandle texture;
+    vec3_t imm_vec3;
+    float imm_float;
+  };
+};
+
+//! Value with type checking
+/** Type checking will disabled when assertions are disabled.
+ */
+template <ValueType type_, typename T> class TypedValue : public Value {
+public:
+  TypedValue() : Value() {}
+  ~TypedValue() {}
+
+  template <typename F = T,
+            typename std::enable_if<!std::is_same<F, void>::value, int>::type
+                * = nullptr>
+  TypedValue(F value) : Value(value) {}
+
+  explicit TypedValue(const Value &value) : Value(value) {
+    assert(value.get_type() == type_);
+  }
+
+  explicit TypedValue(const NodeHandle &node);
+};
+
+using OutputValue = TypedValue<ValueType::OUTPUT, void>;
+using Vec3Value = TypedValue<ValueType::VEC3, vec3_t>;
+using FloatValue = TypedValue<ValueType::FLOAT, float>;
+using TextureValue = TypedValue<ValueType::TEXTURE, TextureHandle>;
+
+using OffsetToValue = std::ptrdiff_t;
+
+#define RETURN_TYPE(RT)                                                        \
+  ValueType get_return_type() const override { return ValueType::RT; }
+
+#define FIELD_TO_PTR(CLS_NAME, X) offsetof(CLS_NAME, X)
+
+#define NODE_VALUES_DEF(CLS_NAME, ...)                                         \
+  const core::vector<OffsetToValue> CLS_NAME::value_offsets = {                \
+      APPLY_2(FIELD_TO_PTR, CLS_NAME, __VA_ARGS__)};
+
+// FIXME: remove this
+// we get error C2760: syntax error: unexpected token 'End of Token Stream',
+// expected 'id-expression' without this
+#define NODE_NO_VALUES_DEF(CLS_NAME)                                           \
+  const core::vector<OffsetToValue> CLS_NAME::value_offsets = {};
+
+template <typename T>
+NBL_FORCE_INLINE bool field_compare(const T &lhs, const T &rhs) {
+  return lhs == rhs;
+}
+
+template <>
+NBL_FORCE_INLINE bool field_compare(const vec3_t &lhs, const vec3_t &rhs) {
+  return (lhs == rhs).all();
+}
+
+#define FIELD_TO_COMPARE(OTHER, X) field_compare(X, OTHER.X)
+
+#define NODE_FIELDS_DEF(CLS_NAME, ...)                                         \
+  NodeHandle CLS_NAME::clone(IRDAG &dag) const {                               \
+    NodeHandle node = dag.create_node<CLS_NAME>();                             \
+    reinterpret_cast<CLS_NAME &>(*node) = *this;                               \
+    return node;                                                               \
+  }                                                                            \
+  INodeHash CLS_NAME::get_hash() const {                                       \
+    return hash_fields(symbol, __VA_ARGS__);                                   \
+  }                                                                            \
+  bool CLS_NAME::equals(const INode &other_) const {                           \
+    const CLS_NAME &other = static_cast<const CLS_NAME &>(other_);             \
+    bool comparison[] = {APPLY_2(FIELD_TO_COMPARE, other, __VA_ARGS__)};       \
+    bool res = true;                                                           \
+    for (bool c : comparison)                                                  \
+      res &= c;                                                                \
+    return res;                                                                \
+  }
+
+#define NODE_DECL(NT)                                                          \
+  static const core::vector<OffsetToValue> value_offsets;                      \
+  const core::vector<OffsetToValue> &get_value_offsets() override {            \
+    return value_offsets;                                                      \
+  }                                                                            \
+  INodeHash get_hash() const override;                                         \
+  NodeHandle clone(IRDAG &dag) const override;                                 \
+                                                                               \
+protected:                                                                     \
+  bool equals(const INode &other) const override;                              \
+                                                                               \
+public:
+
+template <typename T> INodeHash node_hash(const T &value) {
+  return core::fnv_hash(value);
+}
+
+template <> INodeHash node_hash(const Value &value) { return value.get_hash(); }
+
+struct INode {
+  enum E_SYMBOL : uint8_t {
+    ES_NORMAL_MODIFIER,
+    ES_TEXTURE_PREFETCH,
+    ES_EMISSION,
+    ES_OPACITY,
+    ES_BSDF,
+    ES_BSDF_COMBINER
+  };
+
+  virtual ~INode() = default;
+
+  // Get the hash of this subtree
+  virtual INodeHash get_hash() const = 0;
+  // Get the return type of this node; either OUTPUT or VEC3
+  virtual ValueType get_return_type() const = 0;
+  // Get the values of this node
+  virtual const core::vector<OffsetToValue> &get_value_offsets() = 0;
+  // Clone this node
+  virtual NodeHandle clone(IRDAG &dag) const = 0;
+
+  bool operator==(const INode &other) const {
+    if (!compare_node_type(other))
+      return false;
+    return equals(other);
+  }
+
+  virtual bool compare_node_type(const INode &other) const {
+    return symbol == other.symbol;
+  }
+
+  Value &value(OffsetToValue offset) {
+    return *reinterpret_cast<Value *>(reinterpret_cast<uint8_t *>(this) +
+                                      offset);
+  }
+
+  E_SYMBOL symbol;
+
+protected:
+  INode(E_SYMBOL s) : symbol(s) {}
+
+  // Deep compare node of same type
+  virtual bool equals(const INode &other) const = 0;
+
+  template <typename... Args>
+  NBL_FORCE_INLINE INodeHash hash_fields(Args &&...args) const {
+    return 0 ^ (node_hash(std::forward<Args>(args)) ^ ...);
+  }
+};
+
+#define COMBINE_NODE_FIELDS_DEF(CLS_NAME, ...)                                 \
+  NODE_FIELDS_DEF(CLS_NAME, type, ##__VA_ARGS__)
+#define COMBINE_NODE_VALUES_DEF(CLS_NAME, ...)                                 \
+  NODE_VALUES_DEF(CLS_NAME, __VA_ARGS__)
+
+struct IBSDFCombinerNode : INode {
+  enum E_TYPE {
+    // mix of N BSDFs
+    ET_MIX,
+    // blend of 2 BSDFs weighted by constant or texture
+    ET_WEIGHT_BLEND,
+    // for support of nvidia MDL's df::fresnel_layer
+    ET_LOL_MDL_SUX_BROKEN_FRESNEL_BLEND,
+    // blend of 2 BSDFs weighted by custom direction-based curve
+    ET_CUSTOM_CURVE_BLEND
+  };
+
+  bool compare_node_type(const INode &other) const override {
+    if (!INode::compare_node_type(other))
+      return false;
+    return type == static_cast<const IBSDFCombinerNode &>(other).type;
+  }
+
+  E_TYPE type;
+
+protected:
+  IBSDFCombinerNode(E_TYPE t) : INode(ES_BSDF_COMBINER), type(t) {}
+};
+
+#define BSDF_FIELDS_DEF(CLS_NAME, ...)                                         \
+  NODE_FIELDS_DEF(CLS_NAME, type, normal, ##__VA_ARGS__)
+#define BSDF_VALUES_DEF(CLS_NAME, ...)                                         \
+  NODE_VALUES_DEF(CLS_NAME, normal, ##__VA_ARGS__)
+
+struct IBSDFNode : INode {
+  ~IBSDFNode() = default;
+  enum E_TYPE {
+    ET_MICROFACET_DIFFTRANS,
+    ET_MICROFACET_DIFFUSE,
+    ET_MICROFACET_SPECULAR,
+    ET_MICROFACET_COATING,
+    ET_MICROFACET_DIELECTRIC,
+    ET_DELTA_TRANSMISSION
+    // ET_SHEEN,
+  };
+
+  bool compare_node_type(const INode &other) const override {
+    if (!INode::compare_node_type(other))
+      return false;
+    return type == static_cast<const IBSDFNode &>(other).type;
+  }
+
+  E_TYPE type;
+  // normal will be lowered to normal cache update operations in backend
+  Vec3Value normal = vec3_t(.0f);
+
+protected:
+  IBSDFNode(E_TYPE t) : INode(ES_BSDF), type(t) {}
+};
+
+#define MS_BSDF_FIELDS_DEF(CLS_NAME, ...)                                      \
+  BSDF_FIELDS_DEF(CLS_NAME, ndf, shadowing, alpha_u, alpha_v, ##__VA_ARGS__)
+#define MS_BSDF_VALUES_DEF(CLS_NAME, ...)                                      \
+  BSDF_VALUES_DEF(CLS_NAME, alpha_u, alpha_v, ##__VA_ARGS__)
+
+struct IMicrofacetSpecularBSDFBase : IBSDFNode {
+  enum E_NDF { ENDF_BECKMANN, ENDF_GGX, ENDF_ASHIKHMIN_SHIRLEY, ENDF_PHONG };
+  // TODO: Remove, the NDF fixes the geometrical shadowing and masking function.
+  enum E_SHADOWING_TERM { EST_SMITH, EST_VCAVITIES };
+
+  ~IMicrofacetSpecularBSDFBase() = default;
+
+  void setSmooth(E_NDF _ndf = ENDF_GGX) {
+    ndf = _ndf;
+    alpha_u = 0.f;
+    alpha_v = 0.f;
+  }
+
+  E_NDF ndf = ENDF_GGX;
+  E_SHADOWING_TERM shadowing = EST_SMITH;
+  FloatValue alpha_u = 0.f;
+  FloatValue alpha_v = 0.f;
+
+protected:
+  IMicrofacetSpecularBSDFBase(E_TYPE t) : IBSDFNode(t) {}
+};
+
+#define MD_BSDF_FIELDS_DEF(CLS_NAME, ...)                                      \
+  BSDF_FIELDS_DEF(CLS_NAME, alpha_u, alpha_v, ##__VA_ARGS__)
+#define MD_BSDF_VALUES_DEF(CLS_NAME, ...)                                      \
+  BSDF_VALUES_DEF(CLS_NAME, alpha_u, alpha_v, ##__VA_ARGS__)
+
+struct IMicrofacetDiffuseBxDFBase : IBSDFNode {
+  ~IMicrofacetDiffuseBxDFBase() = default;
+
+  void setSmooth() {
+    alpha_u = 0.f;
+    alpha_v = 0.f;
+  }
+
+  FloatValue alpha_u = 0.f;
+  FloatValue alpha_v = 0.f;
+
+protected:
+  IMicrofacetDiffuseBxDFBase(E_TYPE t) : IBSDFNode(t) {}
+};
+
+struct CTexturePrefetchNode final : INode {
+  enum E_TEXCEL_TYPE : uint8_t { ETT_VEC3, ETT_FLOAT };
+
+  CTexturePrefetchNode() : INode(ES_TEXTURE_PREFETCH) {}
+  ~CTexturePrefetchNode() = default;
+
+  ValueType get_return_type() const override {
+    return texcel_type == ETT_VEC3 ? ValueType::VEC3 : ValueType::FLOAT;
+  }
+  NODE_DECL(CTexturePrefetchNode)
+
+  E_TEXCEL_TYPE texcel_type = ETT_VEC3;
+  TextureValue texture;
+};
+
+struct CNomralModifierNode final : INode {
+  enum E_TYPE : uint8_t {
+    ET_DISPLACEMENT,
+    ET_HEIGHT,
+    ET_NORMAL,
+    ET_DERIVATIVE
+  };
+
+  enum E_SOURCE : uint8_t { ESRC_UV_FUNCTION, ESRC_TEXTURE };
+
+  CNomralModifierNode() : INode(ES_NORMAL_MODIFIER) {}
+  CNomralModifierNode(E_TYPE t) : INode(ES_NORMAL_MODIFIER), type(t) {}
+  ~CNomralModifierNode() = default;
+
+  NODE_DECL(CNomralModifierNode)
+  RETURN_TYPE(OUTPUT)
+
+  E_TYPE type = ET_DISPLACEMENT;
+  // no other (than texture) source supported for now (uncomment in the future)
+  // [far future TODO] E_SOURCE source;
+  // TODO when source==ESRC_UV_FUNCTION, use the proper Value representation
+  // from some node in fact when we want to translate MDL function of (u,v) into
+  // this IR we could just create an image being a 2D plot of this function with
+  // some reasonable quantization (pixel dimensions)
+  Vec3Value value = vec3_t(0.f);
+};
+
+struct CEmissionNode final : INode {
+  CEmissionNode() : INode(ES_EMISSION) {}
+  ~CEmissionNode() = default;
+
+  NODE_DECL(CEmissionNode)
+  RETURN_TYPE(OUTPUT)
+
+  vec3_t intensity = vec3_t(1.f);
+};
+
+struct COpacityNode final : INode {
+  COpacityNode() : INode(ES_OPACITY) {}
+  ~COpacityNode() = default;
+
+  NODE_DECL(COpacityNode)
+  RETURN_TYPE(OUTPUT)
+
+  Vec3Value opacity = vec3_t(0.f);
+  OutputValue bxdf;
+};
+
+struct CBSDFBlendNode final : IBSDFCombinerNode {
+  CBSDFBlendNode() : IBSDFCombinerNode(ET_WEIGHT_BLEND) {}
+  ~CBSDFBlendNode() = default;
+
+  RETURN_TYPE(OUTPUT)
+  NODE_DECL(CBSDFBlendNode)
+
+  Vec3Value weight = vec3_t(0.f);
+  OutputValue bxdf;
+};
+
+struct CBSDFMixNode final : IBSDFCombinerNode {
+  CBSDFMixNode() : IBSDFCombinerNode(ET_MIX) {}
+  ~CBSDFMixNode() = default;
+
+  RETURN_TYPE(OUTPUT)
+  NODE_DECL(CBSDFMixNode)
+
+  OutputValue bxdf1;
+  OutputValue bxdf2;
+};
+
+struct CMicrofacetSpecularBSDFNode final : IMicrofacetSpecularBSDFBase {
+  CMicrofacetSpecularBSDFNode()
+      : IMicrofacetSpecularBSDFBase(ET_MICROFACET_SPECULAR) {}
+  ~CMicrofacetSpecularBSDFNode() = default;
+
+  RETURN_TYPE(OUTPUT)
+  NODE_DECL(CMicrofacetSpecularBSDFNode)
+};
+
+struct CMicrofacetCoatingBSDFNode final : IMicrofacetSpecularBSDFBase {
+  CMicrofacetCoatingBSDFNode()
+      : IMicrofacetSpecularBSDFBase(ET_MICROFACET_COATING) {}
+  ~CMicrofacetCoatingBSDFNode() = default;
+
+  RETURN_TYPE(OUTPUT)
+  NODE_DECL(CMicrofacetCoatingBSDFNode)
+
+  Vec3Value thicknessSigmaA = vec3_t(0.0f);
+};
+
+struct CMicrofacetDielectricBSDFNode final : IMicrofacetSpecularBSDFBase {
+  CMicrofacetDielectricBSDFNode()
+      : IMicrofacetSpecularBSDFBase(ET_MICROFACET_DIELECTRIC) {}
+  ~CMicrofacetDielectricBSDFNode() = default;
+
+  RETURN_TYPE(OUTPUT)
+  NODE_DECL(CMicrofacetDielectricBSDFNode)
+
+  bool thin = false;
+};
+
+struct CMicrofacetDiffuseBSDFNode final : IMicrofacetDiffuseBxDFBase {
+  CMicrofacetDiffuseBSDFNode()
+      : IMicrofacetDiffuseBxDFBase(ET_MICROFACET_DIFFUSE) {}
+  ~CMicrofacetDiffuseBSDFNode() = default;
+
+  RETURN_TYPE(OUTPUT)
+  NODE_DECL(CMicrofacetDiffuseBSDFNode)
+
+  Vec3Value reflectance = vec3_t(1.f);
+};
+
+struct CMicrofacetDifftransBSDFNode final : IMicrofacetDiffuseBxDFBase {
+  CMicrofacetDifftransBSDFNode()
+      : IMicrofacetDiffuseBxDFBase(ET_MICROFACET_DIFFTRANS) {}
+  ~CMicrofacetDifftransBSDFNode() = default;
+
+  RETURN_TYPE(OUTPUT)
+  NODE_DECL(CMicrofacetDifftransBSDFNode)
+
+  Vec3Value transmittance = vec3_t(0.5f);
+};
+
+} // namespace nbl::asset::material_compiler::v2::ir
+
+#endif

--- a/include/nbl/core/ApplyMacro.h
+++ b/include/nbl/core/ApplyMacro.h
@@ -1,0 +1,52 @@
+#define EXPAND(x) x
+
+#define APPLY0(M, ...)
+#define APPLY1(M, A, ...) EXPAND(M(A))
+#define APPLY2(M, A, ...) EXPAND(M(A)), EXPAND(APPLY1(M, __VA_ARGS__))
+#define APPLY3(M, A, ...) EXPAND(M(A)), EXPAND(APPLY2(M, __VA_ARGS__))
+#define APPLY4(M, A, ...) EXPAND(M(A)), EXPAND(APPLY3(M, __VA_ARGS__))
+#define APPLY5(M, A, ...) EXPAND(M(A)), EXPAND(APPLY4(M, __VA_ARGS__))
+#define APPLY6(M, A, ...) EXPAND(M(A)), EXPAND(APPLY5(M, __VA_ARGS__))
+#define APPLY7(M, A, ...) EXPAND(M(A)), EXPAND(APPLY6(M, __VA_ARGS__))
+#define APPLY8(M, A, ...) EXPAND(M(A)), EXPAND(APPLY7(M, __VA_ARGS__))
+#define APPLY9(M, A, ...) EXPAND(M(A)), EXPAND(APPLY8(M, __VA_ARGS__))
+#define APPLY10(M, A, ...) EXPAND(M(A)), EXPAND(APPLY9(M, __VA_ARGS__))
+#define APPLY11(M, A, ...) EXPAND(M(A)), EXPAND(APPLY10(M, __VA_ARGS__))
+#define APPLY12(M, A, ...) EXPAND(M(A)), EXPAND(APPLY11(M, __VA_ARGS__))
+#define APPLY_N__(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, X,    \
+                  ...)                                                         \
+  APPLY##X
+#define APPLY(M, ...)                                                          \
+  EXPAND(EXPAND(APPLY_N__(M, __VA_ARGS__, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2,  \
+                          1, 0))(M, __VA_ARGS__)
+
+#define APPLY2_0(M, C) FUCK
+#define APPLY2_1(M, C, A, ...) EXPAND(M(C, A))
+#define APPLY2_2(M, C, A, ...)                                                 \
+  EXPAND(M(C, A)), EXPAND(APPLY2_1(M, C, __VA_ARGS__))
+#define APPLY2_3(M, C, A, ...)                                                 \
+  EXPAND(M(C, A)), EXPAND(APPLY2_2(M, C, __VA_ARGS__))
+#define APPLY2_4(M, C, A, ...)                                                 \
+  EXPAND(M(C, A)), EXPAND(APPLY2_3(M, C, __VA_ARGS__))
+#define APPLY2_5(M, C, A, ...)                                                 \
+  EXPAND(M(C, A)), EXPAND(APPLY2_4(M, C, __VA_ARGS__))
+#define APPLY2_6(M, C, A, ...)                                                 \
+  EXPAND(M(C, A)), EXPAND(APPLY2_5(M, C, __VA_ARGS__))
+#define APPLY2_7(M, C, A, ...)                                                 \
+  EXPAND(M(C, A)), EXPAND(APPLY2_6(M, C, __VA_ARGS__))
+#define APPLY2_8(M, C, A, ...)                                                 \
+  EXPAND(M(C, A)), EXPAND(APPLY2_7(M, C, __VA_ARGS__))
+#define APPLY2_9(M, C, A, ...)                                                 \
+  EXPAND(M(C, A)), EXPAND(APPLY2_8(M, C, __VA_ARGS__))
+#define APPLY2_10(M, C, A, ...)                                                \
+  EXPAND(M(C, A)), EXPAND(APPLY2_9(M, C, __VA_ARGS__))
+#define APPLY2_11(M, C, A, ...)                                                \
+  EXPAND(M(C, A)), EXPAND(APPLY2_10(M, C, __VA_ARGS__))
+#define APPLY2_12(M, C, A, ...)                                                \
+  EXPAND(M(C, A)), EXPAND(APPLY2_11(M, C, __VA_ARGS__))
+#define APPLY2_N__(_0, _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, X,   \
+                   ...)                                                        \
+  APPLY2_##X
+#define APPLY_2(M, C, ...)                                                     \
+  EXPAND(EXPAND(APPLY2_N__(M, __VA_ARGS__, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, \
+                           1, 0))(M, C, __VA_ARGS__))

--- a/include/nbl/core/math/fnvhash.h
+++ b/include/nbl/core/math/fnvhash.h
@@ -1,0 +1,46 @@
+// Copyright (C) 2018-2023 - DevSH Graphics Programming Sp. z O.O.
+// This file is part of the "Nabla Engine".
+// For conditions of distribution and use, see copyright notice in nabla.h
+
+#ifndef __NBL_CORE_FNV_HASH_H_INCLUDED__
+#define __NBL_CORE_FNV_HASH_H_INCLUDED__
+
+#include <stdint.h>
+#include <nbl/core/definitions.h>
+
+namespace nbl::core
+{
+
+constexpr uint64_t FNV_SEED = 14695981039346656037ull;
+constexpr uint64_t FNV_PRIME = 1099511628211ull;
+
+template <typename T, typename U>
+NBL_FORCE_INLINE uint64_t fnv_hash_base(const T& value) {
+    const U* buf = reinterpret_cast<const U*>(&value);
+    uint64_t hash_value = FNV_SEED;
+    for (uint64_t i = 0; i < (sizeof(T) / sizeof(U)); i++) {
+        hash_value ^= buf[i];
+        hash_value *= FNV_PRIME;
+    }
+    return hash_value;
+}
+
+// Calculate Fowler–Noll–Vo hash of arbitrary data
+// Note that it's UB when T is struct with padding bytes
+template <typename T>
+NBL_FORCE_INLINE uint64_t fnv_hash(const T& value) {
+    if constexpr (is_aligned_to(sizeof(T), 8))
+        return fnv_hash_base<T, uint64_t>(value);
+
+    if constexpr (is_aligned_to(sizeof(T), 4))
+        return fnv_hash_base<T, uint32_t>(value);
+
+    if constexpr (is_aligned_to(sizeof(T), 2))
+        return fnv_hash_base<T, uint16_t>(value);
+
+    return fnv_hash_base<T, uint8_t>(value);
+}
+
+}
+
+#endif

--- a/src/nbl/CMakeLists.txt
+++ b/src/nbl/CMakeLists.txt
@@ -295,6 +295,8 @@ set(NBL_ASSET_SOURCES
 # Material compiler
 	${NBL_ROOT_PATH}/src/nbl/asset/material_compiler/CMaterialCompilerGLSLBackendCommon.cpp
 	${NBL_ROOT_PATH}/src/nbl/asset/material_compiler/CMaterialCompilerGLSLRasterBackend.cpp
+
+	${NBL_ROOT_PATH}/src/nbl/asset/material_compiler/v2/IRNode.cpp
 )
 set(NBL_VIDEO_SOURCES
 # Allocators

--- a/src/nbl/asset/material_compiler/v2/IRNode.cpp
+++ b/src/nbl/asset/material_compiler/v2/IRNode.cpp
@@ -1,0 +1,92 @@
+#include <nbl/asset/material_compiler/v2/IR.h>
+#include <nbl/asset/material_compiler/v2/IRNode.h>
+
+using namespace nbl::asset::material_compiler::v2::ir;
+using namespace nbl;
+
+ValueType Value::get_type() const {
+  if (is_node()) {
+    return node->get_return_type();
+  }
+  return type;
+}
+
+INodeHash Value::get_hash() const {
+  switch (type) {
+  case ValueType::NODE: {
+    return node->get_hash();
+  }
+  case ValueType::TEXTURE: {
+    return texture->get_hash();
+  }
+  case ValueType::FLOAT: {
+    return core::fnv_hash(imm_float);
+  }
+  case ValueType::VEC3: {
+    return core::fnv_hash(imm_vec3);
+  }
+  case ValueType::NONE: {
+    assert(false && "Hashing of none value");
+  }
+  }
+}
+
+bool Value::operator==(const Value &other) const {
+  if (type != other.type)
+    return false;
+  switch (type) {
+  case ValueType::NODE: {
+    return *node == *other.node;
+  }
+  case ValueType::TEXTURE: {
+    return *texture == *other.texture;
+  }
+  case ValueType::FLOAT: {
+    return imm_float == other.imm_float;
+  }
+  case ValueType::VEC3: {
+    return (imm_vec3 == other.imm_vec3).all();
+  }
+  case ValueType::NONE: {
+    assert(false && "Comparison of none value");
+  }
+  }
+}
+
+template <ValueType type_, typename T>
+TypedValue<type_, T>::TypedValue(const NodeHandle &node) : Value(node) {
+  assert(node->get_return_type() == type_);
+}
+
+NODE_FIELDS_DEF(CTexturePrefetchNode, texcel_type, texture)
+NODE_VALUES_DEF(CTexturePrefetchNode, texture)
+
+NODE_FIELDS_DEF(CNomralModifierNode, type, value)
+NODE_VALUES_DEF(CNomralModifierNode, value)
+
+NODE_FIELDS_DEF(CEmissionNode, intensity)
+NODE_NO_VALUES_DEF(CEmissionNode)
+
+NODE_FIELDS_DEF(COpacityNode, opacity, bxdf)
+NODE_VALUES_DEF(COpacityNode, bxdf)
+
+COMBINE_NODE_FIELDS_DEF(CBSDFBlendNode, weight, bxdf)
+COMBINE_NODE_VALUES_DEF(CBSDFBlendNode, weight, bxdf)
+
+COMBINE_NODE_FIELDS_DEF(CBSDFMixNode, bxdf1, bxdf2)
+COMBINE_NODE_VALUES_DEF(CBSDFMixNode, bxdf1, bxdf2)
+
+MS_BSDF_FIELDS_DEF(CMicrofacetSpecularBSDFNode)
+MS_BSDF_VALUES_DEF(CMicrofacetSpecularBSDFNode)
+
+MS_BSDF_FIELDS_DEF(CMicrofacetCoatingBSDFNode, thicknessSigmaA)
+MS_BSDF_VALUES_DEF(CMicrofacetCoatingBSDFNode, thicknessSigmaA)
+
+MS_BSDF_FIELDS_DEF(CMicrofacetDielectricBSDFNode, thin)
+MS_BSDF_VALUES_DEF(CMicrofacetDielectricBSDFNode)
+
+MD_BSDF_FIELDS_DEF(CMicrofacetDiffuseBSDFNode)
+MD_BSDF_VALUES_DEF(CMicrofacetDiffuseBSDFNode)
+
+MD_BSDF_FIELDS_DEF(CMicrofacetDifftransBSDFNode, transmittance)
+MD_BSDF_VALUES_DEF(CMicrofacetDifftransBSDFNode, transmittance)


### PR DESCRIPTION
## Description
Very rough draft that shows new IR interface with POC insert_subdag, dead_strip, subexpression_elimination implementation.

It introduces "Value" abstraction that tries to solve multiple issues:
- Now don't have to maintain "children" array even if the node will not ever have children list
- Proper hashing of "normal mapped" subtree; by having normal "Value" inside all bsdf node if bsdf uses different normal, the hash of subtree will be different
- Arbitrary subexpression elimination can remove unnecessary texture prefetch or normal precomputation without need of separate pass (just typical subexpression elimination will remove it since hash is same)
- Open up possibility of supporting arbitrary expression (not major point but nice to have)

## TODO list:
- Make code compile
- Testing infrastructure
- Logging support
- Port mitsuaba frontend
- Implement VM backend (possibly in HLSL)
