### PR TITLE
Fix DXC encapsulation in CHLSLCompiler

### DIFF
--- a/include/nbl/asset/utils/CHLSLCompiler.h
+++ b/include/nbl/asset/utils/CHLSLCompiler.h
@@ -8,12 +8,10 @@
 #include "nbl/asset/utils/ISPIRVOptimizer.h"
 #include "nbl/asset/utils/IShaderCompiler.h"
 
-class IDxcUtils;
-class IDxcCompiler3;
-class DxcCompilationResult;
-
-#include <wrl.h>
-#include <combaseapi.h>
+namespace nbl::asset::hlsl::impl
+{
+	class DXC;
+}
 
 namespace nbl::asset
 {
@@ -50,13 +48,7 @@ class NBL_API2 CHLSLCompiler final : public IShaderCompiler
 		void insertIntoStart(std::string& code, std::ostringstream&& ins) const override;
 	protected:
 
-		Microsoft::WRL::ComPtr<IDxcUtils> m_dxcUtils;
-		Microsoft::WRL::ComPtr<IDxcCompiler3> m_dxcCompiler;
-
-		DxcCompilationResult dxcCompile(std::string& source, LPCWSTR* args, uint32_t argCount, const CHLSLCompiler::SOptions& options) const;
-
-		IDxcUtils* getDxcUtils() const { return m_dxcUtils.Get(); }
-		IDxcCompiler3* getDxcCompiler() const { return m_dxcCompiler.Get(); }
+		std::unique_ptr<nbl::asset::hlsl::impl::DXC> m_dxcCompilerTypes;
 
 		static CHLSLCompiler::SOptions option_cast(const IShaderCompiler::SCompilerOptions& options)
 		{


### PR DESCRIPTION
## Description
Fixes encapsulation of DXC headers on CHLSLCompiler, allowing builds with Nabla as a lib to 1. work and 2. be fast

## Testing 
<!-- Explain how this change was tested. -->
Verified with examples

## TODO list:
<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
