### PR TITLE
Go back from using unique ptr for DXC

### DIFF
--- a/include/nbl/asset/utils/CHLSLCompiler.h
+++ b/include/nbl/asset/utils/CHLSLCompiler.h
@@ -22,6 +22,7 @@ class NBL_API2 CHLSLCompiler final : public IShaderCompiler
 		IShader::E_CONTENT_TYPE getCodeContentType() const override { return IShader::E_CONTENT_TYPE::ECT_HLSL; };
 
 		CHLSLCompiler(core::smart_refctd_ptr<system::ISystem>&& system);
+		~CHLSLCompiler();
 
 		struct SOptions : IShaderCompiler::SCompilerOptions
 		{
@@ -48,7 +49,9 @@ class NBL_API2 CHLSLCompiler final : public IShaderCompiler
 		void insertIntoStart(std::string& code, std::ostringstream&& ins) const override;
 	protected:
 
-		std::unique_ptr<nbl::asset::hlsl::impl::DXC> m_dxcCompilerTypes;
+		// This can't be a unique_ptr due to it being an undefined type 
+		// when Nabla is used as a lib
+		nbl::asset::hlsl::impl::DXC* m_dxcCompilerTypes;
 
 		static CHLSLCompiler::SOptions option_cast(const IShaderCompiler::SCompilerOptions& options)
 		{

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -24,8 +24,8 @@ using Microsoft::WRL::ComPtr;
 namespace nbl::asset::hlsl::impl
 {
     struct DXC {
-        Microsoft::WRL::ComPtr<IDxcUtils> m_dxcUtils;
-        Microsoft::WRL::ComPtr<IDxcCompiler3> m_dxcCompiler;
+        ComPtr<IDxcUtils> m_dxcUtils;
+        ComPtr<IDxcCompiler3> m_dxcCompiler;
     };
 }
 
@@ -40,10 +40,15 @@ CHLSLCompiler::CHLSLCompiler(core::smart_refctd_ptr<system::ISystem>&& system)
     res = DxcCreateInstance(CLSID_DxcCompiler, IID_PPV_ARGS(compiler.GetAddressOf()));
     assert(SUCCEEDED(res));
 
-    m_dxcCompilerTypes = std::unique_ptr<nbl::asset::hlsl::impl::DXC>(new nbl::asset::hlsl::impl::DXC{
+    m_dxcCompilerTypes = new nbl::asset::hlsl::impl::DXC{
         utils,
         compiler
-    });
+    };
+}
+
+CHLSLCompiler::~CHLSLCompiler()
+{
+    delete m_dxcCompilerTypes;
 }
 
 static tcpp::IInputStream* getInputStreamInclude(
@@ -303,7 +308,7 @@ core::smart_refctd_ptr<ICPUShader> CHLSLCompiler::compileToSPIRV(const char* cod
     // const CHLSLCompiler* compiler, nbl::asset::hlsl::impl::DXC* compilerTypes, std::string& source, LPCWSTR* args, uint32_t argCount, const CHLSLCompiler::SOptions& options
     auto compileResult = dxcCompile(
         this, 
-        m_dxcCompilerTypes.get(), 
+        m_dxcCompilerTypes, 
         newCode,
         &arguments[0], 
         hlslOptions.genDebugInfo ? allArgs : nonDebugArgs, 


### PR DESCRIPTION
## Description
Using unique ptr was causing issues with generating default destructor with undefined type, when Nabla was being used as a library.

## Testing 
Verified examples work and destructors get called.
<!-- Explain how this change was tested. -->

## TODO list:
<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
