### PR TITLE
bugfix: address crash releated to clang when compiling promoteBufferFormat or promoteImageFormat

### DIFF
--- a/include/nbl/video/utilities/IUtilities.h
+++ b/include/nbl/video/utilities/IUtilities.h
@@ -7,6 +7,7 @@
 #include "nbl/video/IGPUBuffer.h"
 #include "nbl/video/IGPUImage.h"
 #include "nbl/video/ILogicalDevice.h"
+#include "nbl/video/IPhysicalDevice.h"
 #include "nbl/video/alloc/StreamingTransientDataBuffer.h"
 #include "nbl/video/utilities/CPropertyPoolHandler.h"
 #include "nbl/video/utilities/CScanner.h"


### PR DESCRIPTION
## Description

this is a workaround to a crash observed and tested against clang-14,15,16 for linux. the workaround is just to expand the templates themselves so its quite a bit more verbose then the original code. it doesn't seem too bad though, made sure to keep the API basically the same. 

ref: https://github.com/llvm/llvm-project/issues/60938#issuecomment-1442706682
