### PR TITLE
HLSL compiler updates

### DIFF
--- a/include/nbl/asset/utils/IShaderCompiler.h
+++ b/include/nbl/asset/utils/IShaderCompiler.h
@@ -257,6 +257,8 @@ class NBL_API2 IShaderCompiler : public core::IReferenceCounted
 			}
 		}
 
+		static std::string escapeFilename(std::string&& code);
+
 		static void disableAllDirectivesExceptIncludes(std::string& _code);
 
 		static void reenableDirectives(std::string& _code);

--- a/include/nbl/asset/utils/IShaderCompiler.h
+++ b/include/nbl/asset/utils/IShaderCompiler.h
@@ -20,6 +20,9 @@ namespace nbl::asset
 class NBL_API2 IShaderCompiler : public core::IReferenceCounted
 {
 	public:
+		//string to be replaced with all "#" except those in "#include"
+		static constexpr const char* PREPROC_DIRECTIVE_DISABLER = "_this_is_a_hash_";
+		static constexpr const char* PREPROC_DIRECTIVE_ENABLER = PREPROC_DIRECTIVE_DISABLER;
 
 		class NBL_API2 IIncludeLoader : public core::IReferenceCounted
 		{
@@ -259,6 +262,8 @@ class NBL_API2 IShaderCompiler : public core::IReferenceCounted
 		static void reenableDirectives(std::string& _code);
 
 		static std::string encloseWithinExtraInclGuards(std::string&& _code, uint32_t _maxInclusions, const char* _identifier);
+
+		static uint32_t encloseWithinExtraInclGuardsLeadingLines(uint32_t _maxInclusions);
 
 		virtual IShader::E_CONTENT_TYPE getCodeContentType() const = 0;
 

--- a/src/nbl/asset/utils/CCompilerSet.cpp
+++ b/src/nbl/asset/utils/CCompilerSet.cpp
@@ -57,6 +57,8 @@ core::smart_refctd_ptr<ICPUShader> CCompilerSet::preprocessShader(const ICPUShad
 			return core::make_smart_refctd_ptr<ICPUShader>(resolvedCode.c_str(), stage, IShader::E_CONTENT_TYPE::ECT_GLSL, std::string(shader->getFilepathHint()));
 		}
 		break;
+		case IShader::E_CONTENT_TYPE::ECT_SPIRV:
+			return core::smart_refctd_ptr<ICPUShader>(const_cast<ICPUShader*>(shader));
 		default:
 			return nullptr;
 		}

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -102,13 +102,9 @@ static tcpp::IInputStream* getInputStreamInclude(
     IShaderCompiler::disableAllDirectivesExceptIncludes(res_str);
     res_str = IShaderCompiler::encloseWithinExtraInclGuards(std::move(res_str), maxInclCnt, name.string().c_str());
     res_str = res_str + "\n" +
-        IShaderCompiler::PREPROC_DIRECTIVE_DISABLER + "line " + std::to_string(lineGoBackTo) + " \"" +  includeStack.back().second + "\"\n";
+        IShaderCompiler::PREPROC_DIRECTIVE_DISABLER + "line " + std::to_string(lineGoBackTo).c_str() + " \"" + includeStack.back().second.c_str() + "\"\n";
 
-    // avoid warnings about improperly escaping
-    std::string identifier = name.string().c_str();
-    std::replace(identifier.begin(), identifier.end(), '\\', '/');
-
-    includeStack.push_back(std::pair<uint32_t, std::string>(lineGoBackTo, identifier));
+    includeStack.push_back(std::pair<uint32_t, std::string>(lineGoBackTo, IShaderCompiler::escapeFilename(name.string())));
 
     return new tcpp::StringInputStream(std::move(res_str));
 }

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -21,7 +21,7 @@ using namespace nbl;
 using namespace nbl::asset;
 using Microsoft::WRL::ComPtr;
 
-static constexpr const wchar_t* SHADER_MODEL_PROFILE = L"XX_6_2";
+static constexpr const wchar_t* SHADER_MODEL_PROFILE = L"XX_6_6";
 
 namespace nbl::asset::hlsl::impl
 {

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -110,8 +110,6 @@ static tcpp::IInputStream* getInputStreamInclude(
 
     includeStack.push_back(std::pair<uint32_t, std::string>(lineGoBackTo, identifier));
 
-    printf("included res_str:\n%s\n", res_str.c_str());
-
     return new tcpp::StringInputStream(std::move(res_str));
 }
 

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -200,7 +200,7 @@ std::string CHLSLCompiler::preprocessShader(std::string&& code, IShader::E_SHADE
     // Line 1 comes before all the extra defines in the main shader
     insertIntoStart(code, std::ostringstream(std::string(IShaderCompiler::PREPROC_DIRECTIVE_ENABLER) + "line 1\n"));
 
-    uint32_t defineLeadingLinesMain = 0;
+    uint32_t defineLeadingLinesMain = 1;
     uint32_t leadingLinesImports = IShaderCompiler::encloseWithinExtraInclGuardsLeadingLines(preprocessOptions.maxSelfInclusionCount + 1u);
     if (preprocessOptions.extraDefines.size())
     {

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -341,12 +341,12 @@ core::smart_refctd_ptr<ICPUShader> CHLSLCompiler::compileToSPIRV(const char* cod
     }
 
     auto outSpirv = core::make_smart_refctd_ptr<ICPUBuffer>(compileResult.objectBlob->GetBufferSize());
+    memcpy(outSpirv->getPointer(), compileResult.objectBlob->GetBufferPointer(), compileResult.objectBlob->GetBufferSize());
     
     // Optimizer step
     if (hlslOptions.spirvOptimizer)
         outSpirv = hlslOptions.spirvOptimizer->optimize(outSpirv.get(), hlslOptions.preprocessorOptions.logger);
 
-    memcpy(outSpirv->getPointer(), compileResult.objectBlob->GetBufferPointer(), compileResult.objectBlob->GetBufferSize());
 
     return core::make_smart_refctd_ptr<asset::ICPUShader>(std::move(outSpirv), stage, IShader::E_CONTENT_TYPE::ECT_SPIRV, hlslOptions.preprocessorOptions.sourceIdentifier.data());
 }

--- a/src/nbl/asset/utils/IShaderCompiler.cpp
+++ b/src/nbl/asset/utils/IShaderCompiler.cpp
@@ -12,22 +12,18 @@
 using namespace nbl;
 using namespace nbl::asset;
 
-//string to be replaced with all "#" except those in "#include"
-static constexpr const char* PREPROC_DIRECTIVE_DISABLER = "_this_is_a_hash_";
-static constexpr const char* PREPROC_DIRECTIVE_ENABLER = PREPROC_DIRECTIVE_DISABLER;
-
 //all "#", except those in "#include"/"#version"/"#pragma shader_stage(...)", replaced with `PREPROC_DIRECTIVE_DISABLER`
 void IShaderCompiler::disableAllDirectivesExceptIncludes(std::string& _code)
 {
     // TODO: replace this with a proper-ish proprocessor and includer one day
     std::regex directive("#(?!(include|version|pragma shader_stage))");//all # not followed by "include" nor "version" nor "pragma shader_stage"
     //`#pragma shader_stage(...)` is needed for determining shader stage when `_stage` param of IShaderCompiler functions is set to ESS_UNKNOWN
-    _code = std::regex_replace(_code, directive, PREPROC_DIRECTIVE_DISABLER);
+    _code = std::regex_replace(_code, directive, IShaderCompiler::PREPROC_DIRECTIVE_DISABLER);
 }
 
 void IShaderCompiler::reenableDirectives(std::string& _code)
 {
-    std::regex directive(PREPROC_DIRECTIVE_ENABLER);
+    std::regex directive(IShaderCompiler::PREPROC_DIRECTIVE_ENABLER);
     _code = std::regex_replace(_code, directive, "#");
 }
 
@@ -70,12 +66,23 @@ std::string IShaderCompiler::encloseWithinExtraInclGuards(std::string&& _code, u
         "#ifndef " + defBase_ + std::to_string(_maxInclusions) +
         "\n" +
         // This will get turned back into #line after the directives get re-enabled
-        PREPROC_DIRECTIVE_DISABLER + "line 1 \"" + identifier.c_str() + "\"\n" +
+        IShaderCompiler::PREPROC_DIRECTIVE_DISABLER + "line 1 \"" + identifier.c_str() + "\"\n" +
         _code +
         "\n"
         "#endif"
         "\n\n" +
         genUndefs();
+}
+
+// Amount of lines before the #line after having run encloseWithinExtraInclGuards
+uint32_t IShaderCompiler::encloseWithinExtraInclGuardsLeadingLines(uint32_t _maxInclusions)
+{
+    auto lineDirectiveString = std::string(IShaderCompiler::PREPROC_DIRECTIVE_DISABLER) + "line";
+    std::string str = IShaderCompiler::encloseWithinExtraInclGuards(std::string(""), _maxInclusions, "encloseWithinExtraInclGuardsLeadingLines");
+    size_t lineDirectivePos = str.find(lineDirectiveString);
+    auto substr = str.substr(0, lineDirectivePos - lineDirectiveString.length());
+
+    return std::count(substr.begin(), substr.end(), '\n');
 }
 
 IShaderCompiler::IShaderCompiler(core::smart_refctd_ptr<system::ISystem>&& system)

--- a/src/nbl/asset/utils/IShaderCompiler.cpp
+++ b/src/nbl/asset/utils/IShaderCompiler.cpp
@@ -56,7 +56,7 @@ std::string IShaderCompiler::encloseWithinExtraInclGuards(std::string&& _code, u
         return undefs;
     };
 
-    // HACK: tcpp is having issues parsing the string, so this is a hack/mitigation that could be removed once tcpp is fixed
+    // avoid warnings about improperly escaping
     std::string identifier = _identifier;
     std::replace(identifier.begin(), identifier.end(), '\\', '/');
 

--- a/src/nbl/asset/utils/IShaderCompiler.cpp
+++ b/src/nbl/asset/utils/IShaderCompiler.cpp
@@ -12,6 +12,19 @@
 using namespace nbl;
 using namespace nbl::asset;
 
+std::string IShaderCompiler::escapeFilename(std::string&& code)
+{
+    std::string dest;
+    for (char c : code)
+    {
+        if (c == '\\')
+            dest.append("\\" "\\");
+        else 
+            dest.push_back(c);
+    }
+    return dest;
+}
+
 //all "#", except those in "#include"/"#version"/"#pragma shader_stage(...)", replaced with `PREPROC_DIRECTIVE_DISABLER`
 void IShaderCompiler::disableAllDirectivesExceptIncludes(std::string& _code)
 {
@@ -56,10 +69,7 @@ std::string IShaderCompiler::encloseWithinExtraInclGuards(std::string&& _code, u
         return undefs;
     };
 
-    // avoid warnings about improperly escaping
-    std::string identifier = _identifier;
-    std::replace(identifier.begin(), identifier.end(), '\\', '/');
-
+    std::string identifier = IShaderCompiler::escapeFilename(_identifier);
     return
         genDefs() +
         "\n"

--- a/src/nbl/asset/utils/IShaderCompiler.cpp
+++ b/src/nbl/asset/utils/IShaderCompiler.cpp
@@ -15,6 +15,7 @@ using namespace nbl::asset;
 std::string IShaderCompiler::escapeFilename(std::string&& code)
 {
     std::string dest;
+    dest.reserve(code.size() * 2);
     for (char c : code)
     {
         if (c == '\\')


### PR DESCRIPTION
## Description
- Adds support for custom spirv optimizer settings
- Returns the spirv shader directly on preprocess shader

## Testing 
<!-- Explain how this change was tested. -->
- Compilation was tested with and without a custom optimizer 

## TODO list:

- [x] Figure out how to best get the latest shader model supported
- [x] Correct line reporting by DXC
- [x] Log warnings when there is no error

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
