### PR TITLE
chore: is_pod is deprecated replace with is_trivial

### DIFF
--- a/include/nbl/core/containers/CMemoryPool.h
+++ b/include/nbl/core/containers/CMemoryPool.h
@@ -47,7 +47,7 @@ public:
 
         using traits_t = std::allocator_traits<DataAllocator<T>>;
         DataAllocator<T> data_alctr;
-        if constexpr (sizeof...(FuncArgs)!=0u || !std::is_pod_v<T>)
+        if constexpr (sizeof...(FuncArgs)!=0u || !std::is_trivial<T>)
         {
             for (uint32_t i = 0u; i < n; ++i)
                 traits_t::construct(data_alctr, reinterpret_cast<T*>(ptr) + i, std::forward<FuncArgs>(args)...);


### PR DESCRIPTION
## Description
is_pod_v is deprecated in C++20 this replaces the same line with `is_trivial`

https://en.cppreference.com/w/cpp/types/is_trivial