### PR TITLE
bugfix: address memory assertions for command pool

### DIFF
--- a/include/nbl/core/memory/memory.h
+++ b/include/nbl/core/memory/memory.h
@@ -49,7 +49,7 @@ namespace impl
         if (alignment < MIN_ALIGN) alignment = MIN_ALIGN;
         if (size == 0) return nullptr;
         void* p;
-        if (::posix_memalign(&p, alignment>alignof(std::max_align_t) ? alignof(std::max_align_t):alignment, size) != 0) p = nullptr;
+        if (::posix_memalign(&p, alignment, size) != 0) p = nullptr;
         return p;
     }
 }

--- a/include/nbl/video/IGPUCommandPool.h
+++ b/include/nbl/video/IGPUCommandPool.h
@@ -344,7 +344,10 @@ private:
         }
 
         CCommandSegment* m_head = nullptr;
-        core::CMemoryPool<core::PoolAddressAllocator<uint32_t>, core::default_aligned_allocator, false, uint32_t> m_pool;
+        
+        template <typename T>
+        using pool_alignment = core::aligned_allocator<T,COMMAND_SEGMENT_ALIGNMENT>;
+        core::CMemoryPool<core::PoolAddressAllocator<uint32_t>, pool_alignment, false, uint32_t> m_pool;
     };
 
     friend class IGPUCommandBuffer;


### PR DESCRIPTION
## Description
I was observing an assertion on IGPUCommandPool.
```
Alloc'ed 0x5555573aec80 with 56
Alloc'ed 0x5555573749c0 with 56
Alloc'ed 0x555556e9b230 with 56
Alloc'ed 0x555556e9c4d0 with 56
Alloc'ed 0x5555571e8410 with 128
Alloc'ed 0x555556ea5610 with 128
Alloc'ed 0x555556eaabc0 with 128
Alloc'ed 0x5555573fd0c0 with 128
Alloc'ed 0x55555734a090 with 128
Alloc'ed 0x7fffddfff010 with 33556544
helloworld_d: /home/michaelpollind/projects/Nabla/include/nbl/video/IGPUCommandPool.h:66: nbl::video::IGPUCommandPool::ICommand::ICommand(uint32_t): Assertion `ptrdiff_t(this) % alignof(ICommand) == 0' failed.

Thread 1 "helloworld_d" received signal SIGABRT, Aborted.
```

by default the pool allocates on a 16 bit boundary so 0x7fffddfff010 is a multiple of 16 but not 64. 

