### PR TITLE
Fix issue with vkDestroyQueuePool not using function table

### DIFF
--- a/src/nbl/video/CVulkanQueryPool.cpp
+++ b/src/nbl/video/CVulkanQueryPool.cpp
@@ -9,9 +9,10 @@ CVulkanQueryPool::~CVulkanQueryPool()
 {
     if(VK_NULL_HANDLE != m_queryPool)
     {
-        const auto originDevice = getOriginDevice();
-        VkDevice vk_device = static_cast<const CVulkanLogicalDevice*>(originDevice)->getInternalObject();
-        vkDestroyQueryPool(vk_device, m_queryPool, nullptr);
+        const CVulkanLogicalDevice* vulkanDevice = static_cast<const CVulkanLogicalDevice*>(getOriginDevice());
+        auto* vk = vulkanDevice->getFunctionTable();
+        VkDevice vk_device = vulkanDevice->getInternalObject();
+        vk->vk.vkDestroyQueryPool(vk_device, m_queryPool, nullptr);
     }
 }
 


### PR DESCRIPTION
## Description
Fixes the destructor for CVulkanQueryPool, which would previously crash as it tries to use a null function from volk as vkDestroyQueryPool.

## Testing 
Tested dropping of the query pool.
<!-- Explain how this change was tested. -->

## TODO list:
<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
