### PR TITLE
Fix Validation Errors and Bumpmaps

### DIFF
--- a/include/nbl/asset/IImage.h
+++ b/include/nbl/asset/IImage.h
@@ -717,7 +717,7 @@ class IImage : public IDescriptor
 			for (auto it2=it+1u; it2!=pRegionsEnd; it2++)
 			{
 				const auto& subresource2 = it2->getDstSubresource();
-				if (!(subresource2.aspectMask&subresource.aspectMask))
+				if (!(subresource2.aspectMask&subresource.aspectMask).value)
 					continue;
 				if (subresource2.mipLevel!=subresource.mipLevel)
 					continue;

--- a/include/nbl/asset/IImage.h
+++ b/include/nbl/asset/IImage.h
@@ -1,9 +1,8 @@
-// Copyright (C) 2018-2020 - DevSH Graphics Programming Sp. z O.O.
+// Copyright (C) 2018-2023 - DevSH Graphics Programming Sp. z O.O.
 // This file is part of the "Nabla Engine".
 // For conditions of distribution and use, see copyright notice in nabla.h
-
-#ifndef __NBL_ASSET_I_IMAGE_H_INCLUDED__
-#define __NBL_ASSET_I_IMAGE_H_INCLUDED__
+#ifndef _NBL_ASSET_I_IMAGE_H_INCLUDED_
+#define _NBL_ASSET_I_IMAGE_H_INCLUDED_
 
 #include "nbl/core/util/bitflag.h"
 #include "nbl/core/containers/refctd_dynamic_array.h"
@@ -136,18 +135,18 @@ class IImage : public IDescriptor
 		};
 		struct SSubresourceRange
 		{
-			E_ASPECT_FLAGS	aspectMask = E_ASPECT_FLAGS::EAF_NONE;
-			uint32_t		baseMipLevel = 0u;
-			uint32_t		levelCount = 0u;
-			uint32_t		baseArrayLayer = 0u;
-			uint32_t		layerCount = 0u;
+			core::bitflag<E_ASPECT_FLAGS>	aspectMask = E_ASPECT_FLAGS::EAF_NONE;
+			uint32_t						baseMipLevel = 0u;
+			uint32_t						levelCount = 0u;
+			uint32_t						baseArrayLayer = 0u;
+			uint32_t						layerCount = 0u;
 		};
 		struct SSubresourceLayers
 		{
-			E_ASPECT_FLAGS	aspectMask = E_ASPECT_FLAGS::EAF_NONE;
-			uint32_t		mipLevel = 0u;
-			uint32_t		baseArrayLayer = 0u;
-			uint32_t		layerCount = 0u;
+			core::bitflag<E_ASPECT_FLAGS>	aspectMask = E_ASPECT_FLAGS::EAF_NONE;
+			uint32_t						mipLevel = 0u;
+			uint32_t						baseArrayLayer = 0u;
+			uint32_t						layerCount = 0u;
 
 			auto operator<=>(const SSubresourceLayers&) const = default;
 		};
@@ -214,7 +213,7 @@ class IImage : public IDescriptor
 			inline bool					isValid() const
 			{
 				// TODO: more complex check of compatible aspects when planar format support arrives
-				if (srcSubresource.aspectMask^dstSubresource.aspectMask)
+				if ((srcSubresource.aspectMask^dstSubresource.aspectMask).value)
 					return false;
 
 				if (srcSubresource.layerCount!=dstSubresource.layerCount)
@@ -235,14 +234,14 @@ class IImage : public IDescriptor
 		};
 		struct SCreationParams
 		{
-			E_TYPE										type;
-			E_SAMPLE_COUNT_FLAGS						samples;
-			E_FORMAT									format;
-			VkExtent3D									extent;
-			uint32_t									mipLevels;
-			uint32_t									arrayLayers;
-			core::bitflag<E_CREATE_FLAGS>				flags = ECF_NONE;
-			core::bitflag<E_USAGE_FLAGS>				usage = EUF_NONE;
+			E_TYPE							type;
+			E_SAMPLE_COUNT_FLAGS			samples;
+			E_FORMAT						format;
+			VkExtent3D						extent;
+			uint32_t						mipLevels;
+			uint32_t						arrayLayers;
+			core::bitflag<E_CREATE_FLAGS>	flags = ECF_NONE;
+			core::bitflag<E_USAGE_FLAGS>	usage = EUF_NONE;
 
 			inline bool operator==(const SCreationParams& rhs) const
 			{
@@ -328,6 +327,8 @@ class IImage : public IDescriptor
 				if (_params.type != ET_2D)
 					return false;
 				if (_params.extent.width != _params.extent.height)
+					return false;
+				if (_params.extent.depth > 1u)
 					return false;
 				if (_params.arrayLayers < 6u)
 					return false;
@@ -587,7 +588,7 @@ class IImage : public IDescriptor
 				//if (!formatHasAspects(m_creationParams.format,subresource.aspectMask))
 					//return false;
 				// The aspectMask member of imageSubresource must only have a single bit set
-				if (!core::bitCount(static_cast<uint32_t>(subresource.aspectMask)) == 1u)
+				if (!core::bitCount<uint32_t>(subresource.aspectMask.value) == 1u)
 					return false;
 				if (subresource.mipLevel >= m_creationParams.mipLevels)
 					return false;

--- a/include/nbl/asset/IImageView.h
+++ b/include/nbl/asset/IImageView.h
@@ -85,7 +85,7 @@ class IImageView : public IDescriptor
 			// ONLY useful when creating multiple views of an image created with EXTENDED_USAGE to use different view formats.
 			// Example: Create SRGB image with usage STORAGE, and two views with formats SRGB and R32_UINT. Then the SRGB view
 			// CANNOT have STORAGE usage because the format doesn't support it, but the R32_UINT can.
-			core::bitflag<IImage::E_USAGE_FLAGS>	subUsages = EUF_NONE;
+			core::bitflag<IImage::E_USAGE_FLAGS>	subUsages = IImage::EUF_NONE;
 			core::smart_refctd_ptr<ImageType>		image;
 			E_TYPE									viewType;
 			E_FORMAT								format;

--- a/include/nbl/asset/IImageView.h
+++ b/include/nbl/asset/IImageView.h
@@ -80,14 +80,12 @@ class IImageView : public IDescriptor
 		struct SCreationParams
 		{
 			E_CREATE_FLAGS							flags = static_cast<E_CREATE_FLAGS>(0);
-#if 0
 			// These are the set of usages for this ImageView, they must be a subset of the usages that `image` was created with.
 			// If you leave it as the default NONE we'll inherit all usages from the `image`, setting it to anything else is
 			// ONLY useful when creating multiple views of an image created with EXTENDED_USAGE to use different view formats.
 			// Example: Create SRGB image with usage STORAGE, and two views with formats SRGB and R32_UINT. Then the SRGB view
 			// CANNOT have STORAGE usage because the format doesn't support it, but the R32_UINT can.
 			core::bitflag<IImage::E_USAGE_FLAGS>	subUsages = EUF_NONE;
-#endif
 			core::smart_refctd_ptr<ImageType>		image;
 			E_TYPE									viewType;
 			E_FORMAT								format;
@@ -111,11 +109,11 @@ class IImageView : public IDescriptor
 			if (imgParams.)
 				return false;
 			*/
-#if 0
+
 			// declared usages that are not a subset
 			if (!imgParams.usage.hasFlags(_params.subUsages))
 				return false;
-#endif
+
 			const bool mutableFormat = imgParams.flags.hasFlags(IImage::ECF_MUTABLE_FORMAT_BIT);
 			const bool blockTexelViewCompatible = imgParams.flags.hasFlags(IImage::ECF_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT);
 			const auto& subresourceRange = _params.subresourceRange;
@@ -235,7 +233,7 @@ class IImageView : public IDescriptor
 					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-viewType-02962
 					if (actualLayerCount!=6u)
 						return false;
-					break;
+					[[fallthrough]];
 				case ET_CUBE_MAP_ARRAY:
 					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-viewType-02961
 					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-viewType-02963

--- a/include/nbl/asset/IImageView.h
+++ b/include/nbl/asset/IImageView.h
@@ -15,8 +15,8 @@ template<class ImageType>
 class IImageView : public IDescriptor
 {
 	public:
-		static inline constexpr size_t remaining_mip_levels = ~static_cast<size_t>(0u);
-		static inline constexpr size_t remaining_array_layers = ~static_cast<size_t>(0u);
+		static inline constexpr uint32_t remaining_mip_levels = ~static_cast<uint32_t>(0u);
+		static inline constexpr uint32_t remaining_array_layers = ~static_cast<uint32_t>(0u);
 
 		// no flags for now, yet
 		enum E_CREATE_FLAGS
@@ -89,8 +89,8 @@ class IImageView : public IDescriptor
 			core::smart_refctd_ptr<ImageType>		image;
 			E_TYPE									viewType;
 			E_FORMAT								format;
-			SComponentMapping						components;
-			IImage::SSubresourceRange				subresourceRange;
+			SComponentMapping						components = {};
+			IImage::SSubresourceRange				subresourceRange = {IImage::EAF_COLOR_BIT,0,remaining_mip_levels,0,remaining_array_layers};
 		};
 		//!
 		inline static bool validateCreationParameters(const SCreationParams& _params)

--- a/include/nbl/asset/IImageView.h
+++ b/include/nbl/asset/IImageView.h
@@ -15,8 +15,8 @@ template<class ImageType>
 class IImageView : public IDescriptor
 {
 	public:
-		_NBL_STATIC_INLINE_CONSTEXPR size_t remaining_mip_levels = ~static_cast<size_t>(0u);
-		_NBL_STATIC_INLINE_CONSTEXPR size_t remaining_array_layers = ~static_cast<size_t>(0u);
+		static inline constexpr size_t remaining_mip_levels = ~static_cast<size_t>(0u);
+		static inline constexpr size_t remaining_array_layers = ~static_cast<size_t>(0u);
 
 		// no flags for now, yet
 		enum E_CREATE_FLAGS

--- a/include/nbl/asset/IImageView.h
+++ b/include/nbl/asset/IImageView.h
@@ -1,9 +1,8 @@
-// Copyright (C) 2018-2020 - DevSH Graphics Programming Sp. z O.O.
+// Copyright (C) 2018-2023 - DevSH Graphics Programming Sp. z O.O.
 // This file is part of the "Nabla Engine".
 // For conditions of distribution and use, see copyright notice in nabla.h
-
-#ifndef __NBL_ASSET_I_IMAGE_VIEW_H_INCLUDED__
-#define __NBL_ASSET_I_IMAGE_VIEW_H_INCLUDED__
+#ifndef _NBL_ASSET_I_IMAGE_VIEW_H_INCLUDED_
+#define _NBL_ASSET_I_IMAGE_VIEW_H_INCLUDED_
 
 #include "nbl/asset/IImage.h"
 
@@ -80,12 +79,20 @@ class IImageView : public IDescriptor
 		};
 		struct SCreationParams
 		{
-			E_CREATE_FLAGS						flags = static_cast<E_CREATE_FLAGS>(0);
-			core::smart_refctd_ptr<ImageType>	image;
-			E_TYPE								viewType;
-			E_FORMAT							format;
-			SComponentMapping					components;
-			IImage::SSubresourceRange			subresourceRange;
+			E_CREATE_FLAGS							flags = static_cast<E_CREATE_FLAGS>(0);
+#if 0
+			// These are the set of usages for this ImageView, they must be a subset of the usages that `image` was created with.
+			// If you leave it as the default NONE we'll inherit all usages from the `image`, setting it to anything else is
+			// ONLY useful when creating multiple views of an image created with EXTENDED_USAGE to use different view formats.
+			// Example: Create SRGB image with usage STORAGE, and two views with formats SRGB and R32_UINT. Then the SRGB view
+			// CANNOT have STORAGE usage because the format doesn't support it, but the R32_UINT can.
+			core::bitflag<IImage::E_USAGE_FLAGS>	subUsages = EUF_NONE;
+#endif
+			core::smart_refctd_ptr<ImageType>		image;
+			E_TYPE									viewType;
+			E_FORMAT								format;
+			SComponentMapping						components;
+			IImage::SSubresourceRange				subresourceRange;
 		};
 		//!
 		inline static bool validateCreationParameters(const SCreationParams& _params)
@@ -97,11 +104,45 @@ class IImageView : public IDescriptor
 				return false;
 
 			const auto& imgParams = _params.image->getCreationParameters();
-			bool mutableFormat = imgParams.flags.hasFlags(IImage::ECF_MUTABLE_FORMAT_BIT);
+			/* TODO: LAter
+			image must have been created with a usage value containing at least one of VK_IMAGE_USAGE_SAMPLED_BIT,
+			VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+			VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, or VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT
+			if (imgParams.)
+				return false;
+			*/
+#if 0
+			// declared usages that are not a subset
+			if (!imgParams.usage.hasFlags(_params.subUsages))
+				return false;
+#endif
+			const bool mutableFormat = imgParams.flags.hasFlags(IImage::ECF_MUTABLE_FORMAT_BIT);
+			const bool blockTexelViewCompatible = imgParams.flags.hasFlags(IImage::ECF_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT);
+			const auto& subresourceRange = _params.subresourceRange;
 			if (mutableFormat)
 			{
-				//if (!isFormatCompatible(_params.format,imgParams.format))
-					//return false;
+				// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageCreateInfo-flags-01573
+				// BlockTexelViewCompatible implies MutableFormat
+				if (blockTexelViewCompatible)
+				{
+					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-image-01583
+					// If image was created with the VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT flag, format must be compatible with,
+					// or must be an uncompressed format that is size-compatible with, the format used to create image
+					if (getTexelOrBlockBytesize(_params.format)!=getTexelOrBlockBytesize(imgParams.format))
+						return false;
+					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-image-07072
+					// If image was created with the VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT flag and
+					// format is a non-compressed format, the levelCount and layerCount members of subresourceRange must both be 1
+					if (!asset::isBlockCompressionFormat(_params.format) && (subresourceRange.levelCount!=1u || subresourceRange.layerCount!=1u))
+						return false;
+				}
+				// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-image-01761
+				// If image was created with the VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT flag, but without the VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT flag,
+				// and if the format of the image is not a multi-planar format, format must be compatible with the format used to create image
+				else if (getFormatClass(_params.format)!=getFormatClass(imgParams.format))
+					return false;
+				else if (asset::isBlockCompressionFormat(_params.format)!=asset::isBlockCompressionFormat(imgParams.format))
+					return false;
 
 				/*
 				TODO: if the format of the image is a multi-planar format, and if subresourceRange.aspectMask
@@ -110,90 +151,51 @@ class IImageView : public IDescriptor
 				as defined in Compatible formats of planes of multi-planar formats
 				*/
 			}
-
-
-			const auto& subresourceRange = _params.subresourceRange;
-
-			if (imgParams.flags.hasFlags(IImage::ECF_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT))
+			else if (_params.format!=imgParams.format)
 			{
-				/*
-				TODO: format must be compatible with, or must be an uncompressed format that is size-compatible with,
-				the format used to create image.
-				*/
-				if (subresourceRange.levelCount!=1u || subresourceRange.layerCount!=1u)
-					return false;
-			}
-			else
-			{
-				if (mutableFormat)
-				{
-					/*
-					TODO: if the format of the image is not a multi-planar format,
-					format must be compatible with the format used to create image,
-					as defined in Format Compatibility Classes
-					*/
-				}
-			}
-
-			if (!mutableFormat || asset::isPlanarFormat(imgParams.format))
-			{
-				/*
-				TODO: format must be compatible with, or must be an uncompressed format that is size-compatible with,
-				the format used to create image.
-				*/
-			}
-
-			/*
-			image must have been created with a usage value containing at least one of VK_IMAGE_USAGE_SAMPLED_BIT,
-			VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
-			VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, or VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT
-			if (imgParams.)
+				// TODO: multi-planar exceptions
 				return false;
-			*/
+			}
 			
+			//! sanity checks
+			
+			// we have some layers
+			if (subresourceRange.layerCount==0u)
+				return false;
+
+			// mip level ranges
 			if (subresourceRange.baseMipLevel>=imgParams.mipLevels)
 				return false;
 			if (subresourceRange.levelCount!=remaining_mip_levels &&
 					(subresourceRange.levelCount==0u ||
 					subresourceRange.baseMipLevel+subresourceRange.levelCount>imgParams.mipLevels))
 				return false;
+
 			auto mipExtent = _params.image->getMipSize(subresourceRange.baseMipLevel);
-			
-			if (subresourceRange.layerCount==0u)
-				return false;
+			auto actualLayerCount = subresourceRange.layerCount;
 
-			bool sourceIs3D = imgParams.type==IImage::ET_3D;
-			bool sourceIs2DCompat = imgParams.flags.hasFlags(IImage::ECF_2D_ARRAY_COMPATIBLE_BIT) && (_params.viewType==ET_2D||_params.viewType==ET_2D_ARRAY);
-			auto actualLayerCount = subresourceRange.layerCount!=remaining_array_layers ? subresourceRange.layerCount:
-										((sourceIs3D&&sourceIs2DCompat ? mipExtent.z:imgParams.arrayLayers)-subresourceRange.baseArrayLayer);
-			bool checkLayers = true;
-			auto hasCubemapProporties = [&](bool isItACubemapArray = false)
+			// the fact that source is 3D is implied by IImage::validateCreationParams
+			const bool sourceIs2DCompat = imgParams.flags.hasFlags(IImage::ECF_2D_ARRAY_COMPATIBLE_BIT);
+			if (subresourceRange.layerCount==remaining_array_layers)
 			{
-				if (!imgParams.flags.hasFlags(IImage::ECF_CUBE_COMPATIBLE_BIT))
-					return false;
-				if (imgParams.samples > 1u)
-					return false;
-				if (imgParams.extent.height != imgParams.extent.width)
-					return false;
-				if (imgParams.extent.depth > 1u)
-					return false;
-				if (actualLayerCount % 6u)
-					return false;
+				if (sourceIs2DCompat && _params.viewType!=ET_3D)
+					actualLayerCount = mipExtent.z;
 				else
-					if (isItACubemapArray)
-					{
-						if (imgParams.arrayLayers < 6u)
-							return false;
-					}
-					else
-						if (imgParams.arrayLayers != 6u)
-							return false;
-						
-				if (subresourceRange.baseArrayLayer + actualLayerCount > imgParams.arrayLayers)
-					return false;
-				return true;
-			};
+					actualLayerCount = imgParams.arrayLayers;
+				actualLayerCount -= subresourceRange.baseArrayLayer;
+			}
 
+			// If image was created with the VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT flag, ... or must be an uncompressed format
+			if (blockTexelViewCompatible && !asset::isBlockCompressionFormat(_params.format))
+			{
+				// In this case, the resulting image view’s texel dimensions equal the dimensions of the selected mip level divided by the compressed texel block size and rounded up.
+				mipExtent = _params.image->getTexelBlockInfo().convertTexelsToBlocks(mipExtent);
+				if (subresourceRange.layerCount==remaining_array_layers)
+					actualLayerCount = 1;
+			}
+			const auto endLayer = actualLayerCount+subresourceRange.baseArrayLayer;
+
+			bool checkLayers = true;
 			switch (_params.viewType)
 			{
 				case ET_1D:
@@ -203,8 +205,6 @@ class IImageView : public IDescriptor
 						return false;
 					[[fallthrough]];
 				case ET_1D_ARRAY:
-					if (imgParams.extent.height>1u || imgParams.extent.depth>1u)
-						return false;
 					break;
 				case ET_2D:
 					if (imgParams.type==IImage::ET_1D)
@@ -213,7 +213,7 @@ class IImageView : public IDescriptor
 						return false;
 					[[fallthrough]];
 				case ET_2D_ARRAY:
-					if (sourceIs3D)
+					if (imgParams.type==IImage::ET_3D)
 					{
 						if (!sourceIs2DCompat)
 							return false;
@@ -226,16 +226,22 @@ class IImageView : public IDescriptor
 							return false;
 						if (subresourceRange.baseArrayLayer>=mipExtent.z)
 							return false;
-						if (subresourceRange.baseArrayLayer+actualLayerCount>mipExtent.z)
+						if (endLayer>mipExtent.z)
 							return false;
 					}
 					break;
-				case ET_CUBE_MAP_ARRAY:
-					if (!hasCubemapProporties(true))
+				case ET_CUBE_MAP:
+					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-viewType-02960
+					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-viewType-02962
+					if (actualLayerCount!=6u)
 						return false;
 					break;
-				case ET_CUBE_MAP:
-					if (!hasCubemapProporties(false))
+				case ET_CUBE_MAP_ARRAY:
+					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-viewType-02961
+					// https://registry.khronos.org/vulkan/specs/1.2/html/vkspec.html#VUID-VkImageViewCreateInfo-viewType-02963
+					if (actualLayerCount%6u)
+						return false;
+					if (!imgParams.flags.hasFlags(IImage::ECF_CUBE_COMPATIBLE_BIT))
 						return false;
 					break;
 				case ET_3D:
@@ -245,15 +251,14 @@ class IImageView : public IDescriptor
 					return false;
 					break;
 			}
+
 			if (checkLayers)
 			{
 				if (subresourceRange.baseArrayLayer>=imgParams.arrayLayers)
 					return false;
-				if (subresourceRange.layerCount!=remaining_array_layers &&
-						(subresourceRange.baseArrayLayer+subresourceRange.layerCount>imgParams.arrayLayers))
+				if (endLayer>imgParams.arrayLayers)
 					return false;
 			}
-
 			return true;
 		}
 

--- a/include/nbl/asset/filters/CBlitImageFilter.h
+++ b/include/nbl/asset/filters/CBlitImageFilter.h
@@ -627,7 +627,10 @@ class CBlitImageFilter : public CImageFilter<CBlitImageFilter<Swizzle,Dither,Nor
 					});
 					// we'll only get here if we have to do coverage adjustment
 					if (needsNormalization && lastPass)
+					{
+						state->normalization.finalize<value_type>();
 						storeToImage(core::rational<int64_t>(cvg_num,cvg_den),axis,outOffsetLayer);
+					}
 				};
 				// filter in X-axis
 				filterAxis(IImage::ET_1D,scaledKernelX);

--- a/include/nbl/asset/filters/CCopyImageFilter.h
+++ b/include/nbl/asset/filters/CCopyImageFilter.h
@@ -49,7 +49,6 @@ class CCopyImageFilter : public CImageFilter<CCopyImageFilter>, public CMatchedS
 				return false;
 
 			return getFormatClass(state->inImage->getCreationParameters().format)==getFormatClass(state->outImage->getCreationParameters().format);
-			return true;
 		}
 
 		template<class ExecutionPolicy>

--- a/include/nbl/asset/filters/CMipMapGenerationImageFilter.h
+++ b/include/nbl/asset/filters/CMipMapGenerationImageFilter.h
@@ -123,7 +123,7 @@ class CMipMapGenerationImageFilter : public CImageFilter<CMipMapGenerationImageF
 			//blit.kernel = Kernel(); // gets default constructed, we should probably do a `static_assert` about this property
 			static_cast<state_base_t&>(blit) = *static_cast<const state_base_t*>(state);
 
-			pseudo_base_t::blit_utils_t::computeScaledKernelPhasedLUT(blit.scratchMemory + pseudo_base_t::getScratchOffset(&blit, pseudo_base_t::ESU_SCALED_KERNEL_PHASED_LUT), blit.inExtentLayerCount, blit.outExtentLayerCount, blit.inImage->getCreationParameters().type, blit.kernelX, blit.kernelY, blit.kernelZ);
+			blit.recomputeScaledKernelPhasedLUT();
 			return blit;
 		}
 };

--- a/include/nbl/asset/filters/CSwizzleAndConvertImageFilter.h
+++ b/include/nbl/asset/filters/CSwizzleAndConvertImageFilter.h
@@ -1,9 +1,8 @@
 // Copyright (C) 2018-2020 - DevSH Graphics Programming Sp. z O.O.
 // This file is part of the "Nabla Engine".
 // For conditions of distribution and use, see copyright notice in nabla.h
-
-#ifndef __NBL_ASSET_C_SWIZZLE_AND_CONVERT_IMAGE_FILTER_H_INCLUDED__
-#define __NBL_ASSET_C_SWIZZLE_AND_CONVERT_IMAGE_FILTER_H_INCLUDED__
+#ifndef _NBL_ASSET_C_SWIZZLE_AND_CONVERT_IMAGE_FILTER_H_INCLUDED_
+#define _NBL_ASSET_C_SWIZZLE_AND_CONVERT_IMAGE_FILTER_H_INCLUDED_
 
 #include "nbl/core/declarations.h"
 
@@ -18,7 +17,7 @@
 namespace nbl::asset
 {
 
-
+// TODO (devsh): remove Normalization states from these bases, doesn't really belong here, should stay in Blit 
 namespace impl
 {
 

--- a/include/nbl/asset/filters/CSwizzleAndConvertImageFilter.h
+++ b/include/nbl/asset/filters/CSwizzleAndConvertImageFilter.h
@@ -17,7 +17,6 @@
 namespace nbl::asset
 {
 
-// TODO (devsh): remove Normalization states from these bases, doesn't really belong here, should stay in Blit 
 namespace impl
 {
 
@@ -57,7 +56,7 @@ class CSwizzleAndConvertImageFilterBase : public CSwizzleableAndDitherableFilter
 			if constexpr (!std::is_void_v<Normalization>)
 			{			
 				assert(kInFormat==EF_UNKNOWN || rInFormat==EF_UNKNOWN);
-				state->normalization.template initialize<decodeBufferType>();
+				state->normalization.template initialize<encodeBufferType>();
 				auto perOutputRegion = [policy,&blockDims,&state,rInFormat](const CMatchedSizeInOutImageFilterCommon::CommonExecuteData& commonExecuteData, CBasicImageFilterCommon::clip_region_functor_t& clip) -> bool
 				{
 					auto normalizePrepass = [&commonExecuteData,&blockDims,&state,rInFormat](uint32_t readBlockArrayOffset, core::vectorSIMDu32 readBlockPos)
@@ -83,6 +82,7 @@ class CSwizzleAndConvertImageFilterBase : public CSwizzleableAndDitherableFilter
 					return true;
 				};
 				CMatchedSizeInOutImageFilterCommon::commonExecute(state,perOutputRegion);
+				state->normalization.finalize<encodeBufferType>();
 			}
 		}
 };

--- a/include/nbl/asset/filters/NormalizationStates.h
+++ b/include/nbl/asset/filters/NormalizationStates.h
@@ -1,7 +1,6 @@
-// Copyright (C) 2018-2020 - DevSH Graphics Programming Sp. z O.O.
+// Copyright (C) 2018-2023 - DevSH Graphics Programming Sp. z O.O.
 // This file is part of the "Nabla Engine".
 // For conditions of distribution and use, see copyright notice in nabla.h
-
 #ifndef _NBL_ASSET_NORMALIZATION_STATES_H_INCLUDED_
 #define _NBL_ASSET_NORMALIZATION_STATES_H_INCLUDED_
 
@@ -40,7 +39,7 @@ class CGlobalNormalizationState
 		void prepass(Tenc* encodeBuffer, const core::vectorSIMDu32& position, uint32_t blockX, uint32_t blockY, uint8_t channels)
 		{
 			static_assert(std::is_floating_point_v<Tenc>, "Integer decode not supported yet!");
-			for (uint8_t channel=0u; channel<4u; ++channel)
+			for (uint8_t channel=0u; channel<channels; ++channel)
 			{
 				const auto val = encodeBuffer[channel];
 				if constexpr (std::is_floating_point_v<Tenc>)
@@ -112,6 +111,23 @@ namespace impl
 
 class CDerivativeMapNormalizationStateBase
 {
+	protected:
+		// we only care about R and G
+		static inline constexpr uint32_t kChannels = 2;
+
+		template<bool isSignedFormat, typename Tenc>
+		void impl(Tenc* encodeBuffer, const core::vectorSIMDu32& position, uint32_t blockX, uint32_t blockY, uint8_t channels) const
+		{
+			static_assert(std::is_floating_point_v<Tenc>, "Encode types must be double or float!");
+
+			if constexpr (isSignedFormat)
+				for (uint8_t channel = 0; channel < kChannels; ++channel)
+					encodeBuffer[channel] = encodeBuffer[channel]/maxAbsPerChannel[channel];
+			else
+				for (uint8_t channel = 0; channel < kChannels; ++channel)
+					encodeBuffer[channel] = encodeBuffer[channel]*0.5f/maxAbsPerChannel[channel]+0.5f;
+		}
+
 	public:
 		inline bool validate() const {return true;}
 
@@ -120,7 +136,7 @@ class CDerivativeMapNormalizationStateBase
 		inline void initialize()
 		{
 			static_assert(std::is_floating_point_v<Tenc>, "Integer encode not supported yet!");
-			std::fill_n(maxAbsPerChannel,4,0.f);
+			std::fill_n(maxAbsPerChannel,kChannels,0.f);
 		}
 
 		//
@@ -128,7 +144,7 @@ class CDerivativeMapNormalizationStateBase
 		void prepass(Tenc* encodeBuffer, const core::vectorSIMDu32& position, uint32_t blockX, uint32_t blockY, uint8_t channels)
 		{
 			static_assert(std::is_floating_point_v<Tenc>, "Integer encode not supported yet!");
-			for (uint8_t channel=0u; channel<4u; ++channel)
+			for (uint8_t channel=0u; channel<kChannels; ++channel)
 				core::atomic_fetch_max(maxAbsPerChannel+channel,core::abs(encodeBuffer[channel]));
 		}
 
@@ -144,6 +160,7 @@ class CDerivativeMapNormalizationStateBase
 		template<typename Tenc>
 		void operator()(E_FORMAT format, Tenc* encodeBuffer, const core::vectorSIMDu32& position, uint32_t blockX, uint32_t blockY, uint8_t channels) const
 		{
+			assert(channels>=kChannels);
 			#ifdef _NBL_DEBUG
 			bool status = isFloatingPointFormat(format)||isNormalizedFormat(format);
 			assert(status);
@@ -155,20 +172,7 @@ class CDerivativeMapNormalizationStateBase
 				impl<false,Tenc>(encodeBuffer,position,blockX,blockY,channels);
 		}
 
-		core::atomic<float> maxAbsPerChannel[4];
-	protected:
-		template<bool isSignedFormat, typename Tenc>
-		void impl(Tenc* encodeBuffer, const core::vectorSIMDu32& position, uint32_t blockX, uint32_t blockY, uint8_t channels) const
-		{
-			static_assert(std::is_floating_point_v<Tenc>, "Encode types must be double or float!");
-
-			if constexpr (isSignedFormat)
-				for (uint8_t channel = 0; channel < channels; ++channel)
-					encodeBuffer[channel] = encodeBuffer[channel]/maxAbsPerChannel[channel];
-			else
-				for (uint8_t channel = 0; channel < channels; ++channel)
-					encodeBuffer[channel] = encodeBuffer[channel]*0.5f/maxAbsPerChannel[channel]+0.5f;
-		}
+		core::atomic<float> maxAbsPerChannel[kChannels];
 };
 
 }
@@ -183,8 +187,8 @@ class CDerivativeMapNormalizationState : public impl::CDerivativeMapNormalizatio
 			static_assert(std::is_floating_point_v<Tenc>, "Integer encode types not supported yet!");
 			if constexpr (isotropic)
 			{
-				const float isotropicMax = core::max(core::max(maxAbsPerChannel[0],maxAbsPerChannel[1]),core::max(maxAbsPerChannel[2],maxAbsPerChannel[3]));
-				for (auto i=0u; i<4u; i++)
+				const float isotropicMax = core::max<float>(maxAbsPerChannel[0],maxAbsPerChannel[1]);
+				for (auto i=0u; i<kChannels; i++)
 					maxAbsPerChannel[i] = isotropicMax;
 			}
 		}

--- a/include/nbl/asset/utils/CDerivativeMapCreator.h
+++ b/include/nbl/asset/utils/CDerivativeMapCreator.h
@@ -1,5 +1,5 @@
-#ifndef __NBL_I_DERIVATIVE_MAP_CREATOR_H_INCLUDED__
-#define __NBL_I_DERIVATIVE_MAP_CREATOR_H_INCLUDED__
+#ifndef _NBL_I_DERIVATIVE_MAP_CREATOR_H_INCLUDED_
+#define _NBL_I_DERIVATIVE_MAP_CREATOR_H_INCLUDED_
 
 #include "nbl/asset/ICPUImage.h"
 #include "nbl/asset/ICPUImageView.h"

--- a/include/nbl/asset/utils/ICPUVirtualTexture.h
+++ b/include/nbl/asset/utils/ICPUVirtualTexture.h
@@ -145,9 +145,7 @@ public:
         blit.scratchMemoryByteSize = blit_filter_t::getRequiredScratchByteSize(&blit);
         blit.scratchMemory = reinterpret_cast<uint8_t*>(_NBL_ALIGNED_MALLOC(blit.scratchMemoryByteSize, _NBL_SIMD_ALIGNMENT));
 
-        const core::vectorSIMDu32 inExtent(blit.inExtent.width, blit.inExtent.height, blit.inExtent.depth, 1);
-        const core::vectorSIMDu32 outExtent(blit.outExtent.width, blit.outExtent.height, blit.outExtent.depth, 1);
-        if (!blit_filter_t::blit_utils_t::computeScaledKernelPhasedLUT(blit.scratchMemory + blit_filter_t::getScratchOffset(&blit, blit_filter_t::ESU_SCALED_KERNEL_PHASED_LUT), inExtent, outExtent, blit.inImage->getCreationParameters().type, blit.kernelX, blit.kernelY, blit.kernelZ))
+        if (!blit.recomputeScaledKernelPhasedLUT())
             return nullptr;
 
         const bool blit_succeeded = blit_filter_t::execute(&blit);

--- a/include/nbl/builtin/shader/loader/mtl/fragment_impl.glsl
+++ b/include/nbl/builtin/shader/loader/mtl/fragment_impl.glsl
@@ -74,7 +74,7 @@ vec4 nbl_sample_Ns(in vec2 uv, in mat2 dUV) { return texture(map_Ns, uv); }
 vec4 nbl_sample_d(in vec2 uv, in mat2 dUV) { return texture(map_d, uv); }
 #endif
 #ifndef _NBL_bump_SAMPLE_FUNCTION_DEFINED_
-vec2 nbl_sample_bump(in vec2 uv, in mat2 dUV) { return texture(map_bump, uv).xy * 2.f - vec2(1.f); }
+vec2 nbl_sample_bump(in vec2 uv, in mat2 dUV) { return texture(map_bump, uv).xy; }
 #endif
 #endif //_NBL_TEXTURE_SAMPLE_FUNCTIONS_DEFINED_
 

--- a/include/nbl/ext/OIT/OIT.h
+++ b/include/nbl/ext/OIT/OIT.h
@@ -61,7 +61,7 @@ class COIT
                     params.queueFamilyIndexCount = 0;
                     params.queueFamilyIndices = nullptr;
                     params.samples = asset::IImage::ESCF_1_BIT;
-                    params.tiling = asset::IImage::ET_OPTIMAL;
+                    params.tiling = video::IGPUImage::ET_OPTIMAL;
                     params.type = asset::IImage::ET_2D;
                     params.usage = asset::IImage::EUF_STORAGE_BIT;
 
@@ -74,9 +74,10 @@ class COIT
                     if (!img || !imgMem.isValid())
                         return nullptr;
 
-                    video::IGPUImageView::SCreationParams vparams;
+                    video::IGPUImageView::SCreationParams vparams = {};
                     vparams.format = params.format;
                     vparams.flags = static_cast<decltype(vparams.flags)>(0);
+                    //vparams.subUsages = ? ? ? ; TODO
                     vparams.viewType = decltype(vparams.viewType)::ET_2D;
                     vparams.subresourceRange.baseArrayLayer = 0u;
                     vparams.subresourceRange.layerCount = 1u;

--- a/include/nbl/ext/ScreenShot/ScreenShot.h
+++ b/include/nbl/ext/ScreenShot/ScreenShot.h
@@ -155,7 +155,7 @@ inline core::smart_refctd_ptr<asset::ICPUImageView> createScreenShot(
 		{
 			auto newCreationParams = cpuNewImage->getCreationParameters();
 
-			asset::ICPUImageView::SCreationParams viewParams;
+			asset::ICPUImageView::SCreationParams viewParams = {};
 			viewParams.flags = static_cast<asset::ICPUImageView::E_CREATE_FLAGS>(0u);
 			viewParams.image = cpuNewImage;
 			viewParams.format = newCreationParams.format;

--- a/include/nbl/ext/ToneMapper/CToneMapper.h
+++ b/include/nbl/ext/ToneMapper/CToneMapper.h
@@ -198,8 +198,9 @@ class CToneMapper : public core::IReferenceCounted, public core::InterfaceUnmova
 
 			auto nativeFormat = image->getCreationParameters().format;
 
-			video::IGPUImageView::SCreationParams params;
+			video::IGPUImageView::SCreationParams params = {};
 			params.flags = static_cast<video::IGPUImageView::E_CREATE_FLAGS>(0u);
+			//params.subUsages = ? ? ? ; TODO
 			params.image = std::move(image);
 			params.viewType = video::IGPUImageView::ET_2D_ARRAY;
 			params.format = usedAsInput ? getInputViewFormat(nativeFormat):getOutputViewFormat(nativeFormat);

--- a/include/nbl/video/IGPUImage.h
+++ b/include/nbl/video/IGPUImage.h
@@ -28,7 +28,6 @@ class IGPUImage : public asset::IImage, public IDeviceMemoryBacked, public IBack
 		};
 		struct SCreationParams : asset::IImage::SCreationParams, IDeviceMemoryBacked::SCreationParams
 		{
-			// stuff below is irrelevant in OpenGL backend
 			E_TILING tiling = ET_OPTIMAL;
 			E_LAYOUT initialLayout = EL_UNDEFINED;
 
@@ -38,6 +37,12 @@ class IGPUImage : public asset::IImage, public IDeviceMemoryBacked, public IBack
 				return *this;
 			}
 		};
+
+		//!
+		inline E_TILING getTiling() const {return m_tiling;}
+
+		//!
+		inline E_LAYOUT getInitialLayout() const { return m_initialLayout; }
 
 		//!
 		E_OBJECT_TYPE getObjectType() const override { return EOT_IMAGE; }
@@ -143,6 +148,8 @@ class IGPUImage : public asset::IImage, public IDeviceMemoryBacked, public IBack
 		virtual const void* getNativeHandle() const = 0;
 
 	protected:
+		const E_TILING m_tiling;
+		const E_LAYOUT m_initialLayout;
 
 		_NBL_INTERFACE_CHILD(IGPUImage) {}
 
@@ -150,7 +157,7 @@ class IGPUImage : public asset::IImage, public IDeviceMemoryBacked, public IBack
 		IGPUImage(core::smart_refctd_ptr<const ILogicalDevice>&& dev,
 			const IDeviceMemoryBacked::SDeviceMemoryRequirements& reqs,
 			SCreationParams&& _params
-		) : IImage(_params), IDeviceMemoryBacked(std::move(_params),reqs), IBackendObject(std::move(dev)) {}
+		) : IImage(_params), IDeviceMemoryBacked(std::move(_params),reqs), IBackendObject(std::move(dev)), m_tiling(_params.tiling), m_initialLayout(_params.initialLayout) {}
 };
 
 

--- a/include/nbl/video/utilities/IGPUObjectFromAssetConverter.h
+++ b/include/nbl/video/utilities/IGPUObjectFromAssetConverter.h
@@ -1064,7 +1064,6 @@ auto IGPUObjectFromAssetConverter::create(const asset::ICPUImage** const _begin,
         assert(newFormat != asset::EF_UNKNOWN); // No feasible supported format found for creating this image
         params.format = newFormat;
 
-#if 0 // TODO: Bump our minimum Vulkan version to 1.2, then implement https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkImageFormatListCreateInfo.html in our API
         // now add the STORAGE USAGE
         if (computeMips)
         {
@@ -1079,7 +1078,6 @@ auto IGPUObjectFromAssetConverter::create(const asset::ICPUImage** const _begin,
                     params.flags |= asset::IImage::ECF_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT;
             }
         }
-#endif
 
         auto gpuimg = _params.device->createImage(std::move(params));
         auto gpuimgMemReqs = gpuimg->getMemoryReqs();

--- a/include/nbl/video/utilities/IGPUObjectFromAssetConverter.h
+++ b/include/nbl/video/utilities/IGPUObjectFromAssetConverter.h
@@ -785,16 +785,13 @@ auto IGPUObjectFromAssetConverter::create(const asset::ICPUImage** const _begin,
     const auto assetCount = std::distance(_begin, _end);
     auto res = core::make_refctd_dynamic_array<created_gpu_object_array<asset::ICPUImage> >(assetCount);
 
-    // This should be the other way round because if a queue supports either compute or graphics
-    // but not the other way round
+    // TODO: This should be the other way round because if a queue supports either compute or graphics but not the other way round
     const uint32_t transferFamIx = _params.perQueue[EQU_TRANSFER].queue->getFamilyIndex();
     const uint32_t computeFamIx = _params.perQueue[EQU_COMPUTE].queue ? _params.perQueue[EQU_COMPUTE].queue->getFamilyIndex() : transferFamIx;
 
     bool oneQueue = _params.perQueue[EQU_TRANSFER].queue == _params.perQueue[EQU_COMPUTE].queue;
 
     bool needToGenMips = false;
-    core::vector<IGPUCommandBuffer::SImageMemoryBarrier> imgMemBarriers;
-    imgMemBarriers.reserve(assetCount);
     
     core::unordered_map<const asset::ICPUImage*, core::smart_refctd_ptr<IGPUBuffer>> img2gpubuf;
     for (ptrdiff_t i = 0u; i < assetCount; ++i)

--- a/include/nbl/video/utilities/IGPUVirtualTexture.h
+++ b/include/nbl/video/utilities/IGPUVirtualTexture.h
@@ -157,7 +157,7 @@ protected:
             const uint32_t tilesPerDim = getTilesPerDim();
             const uint32_t extent = tileExtent * tilesPerDim;
 
-            IGPUImage::SCreationParams params;
+            IGPUImage::SCreationParams params = {};
             params.extent = { extent, extent, 1u };
             params.format = imageFormat;
             params.arrayLayers = _layers;
@@ -165,7 +165,7 @@ protected:
             params.type = asset::IImage::ET_2D;
             params.samples = asset::IImage::ESCF_1_BIT;
             params.flags = static_cast<asset::IImage::E_CREATE_FLAGS>(0);
-            // TODO: final layout should be readonly (if there's transfer necessary, then we start in transfer dst) and usage is shader sampled texture
+            // TODO: final layout should be readonly (if there's transfer necessary, then we start in transfer dst)
 
             image = m_logicalDevice->createImage(std::move(params));
             m_logicalDevice->allocate(image->getMemoryReqs(), image.get());

--- a/src/nbl/asset/IAssetManager.cpp
+++ b/src/nbl/asset/IAssetManager.cpp
@@ -363,7 +363,7 @@ void IAssetManager::insertBuiltinAssets()
         info.arrayLayers = 1u;
         info.samples = asset::ICPUImage::ESCF_1_BIT;
         info.flags = static_cast<asset::IImage::E_CREATE_FLAGS>(0u);
-        info.usage = static_cast<asset::IImage::E_USAGE_FLAGS>(asset::IImage::EUF_COLOR_ATTACHMENT_BIT | asset::IImage::EUF_INPUT_ATTACHMENT_BIT | asset::IImage::EUF_SAMPLED_BIT | asset::IImage::EUF_STORAGE_BIT);
+        info.usage = static_cast<asset::IImage::E_USAGE_FLAGS>(asset::IImage::EUF_INPUT_ATTACHMENT_BIT | asset::IImage::EUF_SAMPLED_BIT);
         auto buf = core::make_smart_refctd_ptr<asset::ICPUBuffer>(info.extent.width*info.extent.height*asset::getTexelOrBlockBytesize(info.format));
         memcpy(buf->getPointer(),
             //magenta-grey 2x2 chessboard
@@ -389,11 +389,11 @@ void IAssetManager::insertBuiltinAssets()
     
     //image views
     {
-        asset::ICPUImageView::SCreationParams info;
+        asset::ICPUImageView::SCreationParams info = {};
+        info.flags = static_cast<asset::ICPUImageView::E_CREATE_FLAGS>(0u);
         info.format = dummy2dImage->getCreationParameters().format;
         info.image = dummy2dImage;
         info.viewType = asset::IImageView<asset::ICPUImage>::ET_2D;
-        info.flags = static_cast<asset::ICPUImageView::E_CREATE_FLAGS>(0u);
         info.subresourceRange.aspectMask = asset::IImage::EAF_COLOR_BIT;
         info.subresourceRange.baseArrayLayer = 0u;
         info.subresourceRange.layerCount = 1u;

--- a/src/nbl/asset/interchange/CGLILoader.cpp
+++ b/src/nbl/asset/interchange/CGLILoader.cpp
@@ -118,20 +118,20 @@ namespace nbl
 			auto texelBuffer = core::make_smart_refctd_ptr<ICPUBuffer>(texture.size());
 			auto data = reinterpret_cast<uint8_t*>(texelBuffer->getPointer());
 
-			ICPUImage::SCreationParams imageInfo;
-			imageInfo.format = format.first;
+			ICPUImage::SCreationParams imageInfo = {};
 			imageInfo.type = imageType;
-			imageInfo.flags = isItACubemap ? ICPUImage::E_CREATE_FLAGS::ECF_CUBE_COMPATIBLE_BIT : static_cast<ICPUImage::E_CREATE_FLAGS>(0u);
 			imageInfo.samples = ICPUImage::ESCF_1_BIT;
+			imageInfo.format = format.first;
 			imageInfo.extent.width = texture.extent().x;
 			imageInfo.extent.height = texture.extent().y;
 			imageInfo.extent.depth = texture.extent().z;
 			imageInfo.mipLevels = texture.levels();
 			imageInfo.arrayLayers = texture.faces() * texture.layers();
-
-			auto image = ICPUImage::create(std::move(imageInfo));
+			imageInfo.flags = isItACubemap ? ICPUImage::E_CREATE_FLAGS::ECF_CUBE_COMPATIBLE_BIT : static_cast<ICPUImage::E_CREATE_FLAGS>(0u);
+			imageInfo.usage = IImage::EUF_SAMPLED_BIT;
 
 			auto regions = core::make_refctd_dynamic_array<core::smart_refctd_dynamic_array<ICPUImage::SBufferCopy>>(imageInfo.mipLevels);
+			auto image = ICPUImage::create(std::move(imageInfo));
 
 			auto getFullSizeOfRegion = [&](const uint16_t mipLevel) -> uint64_t
 			{
@@ -203,7 +203,7 @@ namespace nbl
 
 			image->setBufferAndRegions(std::move(texelBuffer), regions);
 
-			ICPUImageView::SCreationParams imageViewInfo;
+			ICPUImageView::SCreationParams imageViewInfo = {};
 			imageViewInfo.image = std::move(image);
 			imageViewInfo.format = imageViewInfo.image->getCreationParameters().format;
 			imageViewInfo.viewType = imageViewType;

--- a/src/nbl/asset/interchange/CGraphicsPipelineLoaderMTL.cpp
+++ b/src/nbl/asset/interchange/CGraphicsPipelineLoaderMTL.cpp
@@ -680,7 +680,7 @@ CGraphicsPipelineLoaderMTL::image_views_set_t CGraphicsPipelineLoaderMTL::loadIm
 
         const bool isCubemap = (i == CMTLMetadata::CRenderpassIndependentPipeline::EMP_REFL_POSX);
 
-        ICPUImageView::SCreationParams viewParams;
+        ICPUImageView::SCreationParams viewParams = {};
         viewParams.flags = static_cast<ICPUImageView::E_CREATE_FLAGS>(0u);
         viewParams.format = image->getCreationParameters().format;
         viewParams.viewType = viewType[isCubemap];

--- a/src/nbl/asset/utils/CDerivativeMapCreator.cpp
+++ b/src/nbl/asset/utils/CDerivativeMapCreator.cpp
@@ -187,6 +187,7 @@ core::smart_refctd_ptr<ICPUImage> CDerivativeMapCreator::createDerivativeMapFrom
 	state.scratchMemoryByteSize = DerivativeMapFilter::getRequiredScratchByteSize(&state);
 	state.scratchMemory = reinterpret_cast<uint8_t*>(_NBL_ALIGNED_MALLOC(state.scratchMemoryByteSize, _NBL_SIMD_ALIGNMENT));
 
+	state.recomputeScaledKernelPhasedLUT();
 	const bool result = DerivativeMapFilter::execute(core::execution::par_unseq,&state);
 	if (result)
 	{

--- a/src/nbl/asset/utils/CDerivativeMapCreator.cpp
+++ b/src/nbl/asset/utils/CDerivativeMapCreator.cpp
@@ -206,7 +206,7 @@ core::smart_refctd_ptr<ICPUImageView> CDerivativeMapCreator::createDerivativeMap
 	auto img = createDerivativeMapFromHeightMap<isotropicNormalization>(_inImg, _uwrap, _vwrap, _borderColor, out_normalizationFactor);
 	const auto& iparams = img->getCreationParameters();
 
-	ICPUImageView::SCreationParams params;
+	ICPUImageView::SCreationParams params = {};
 	params.format = iparams.format;
 	params.subresourceRange.baseArrayLayer = 0u;
 	params.subresourceRange.layerCount = iparams.arrayLayers;
@@ -306,7 +306,7 @@ core::smart_refctd_ptr<ICPUImageView> CDerivativeMapCreator::createDerivativeMap
 {
 	auto cpuDerivativeImage = createDerivativeMapFromNormalMap<isotropicNormalization>(_inImg,out_normalizationFactor);
 
-	ICPUImageView::SCreationParams imageViewInfo;
+	ICPUImageView::SCreationParams imageViewInfo = {};
 	imageViewInfo.image = core::smart_refctd_ptr(cpuDerivativeImage);
 	imageViewInfo.format = imageViewInfo.image->getCreationParameters().format;
 	imageViewInfo.viewType = decltype(imageViewInfo.viewType)::ET_2D;

--- a/src/nbl/video/CVulkanCommandBuffer.cpp
+++ b/src/nbl/video/CVulkanCommandBuffer.cpp
@@ -85,14 +85,14 @@ bool CVulkanCommandBuffer::copyImage_impl(const image_t* srcImage, asset::IImage
     VkImageCopy vk_regions[MAX_COUNT];
     for (uint32_t i = 0u; i < regionCount; ++i)
     {
-        vk_regions[i].srcSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].srcSubresource.aspectMask);
+        vk_regions[i].srcSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].srcSubresource.aspectMask.value);
         vk_regions[i].srcSubresource.baseArrayLayer = pRegions[i].srcSubresource.baseArrayLayer;
         vk_regions[i].srcSubresource.layerCount = pRegions[i].srcSubresource.layerCount;
         vk_regions[i].srcSubresource.mipLevel = pRegions[i].srcSubresource.mipLevel;
 
         vk_regions[i].srcOffset = { static_cast<int32_t>(pRegions[i].srcOffset.x), static_cast<int32_t>(pRegions[i].srcOffset.y), static_cast<int32_t>(pRegions[i].srcOffset.z) };
 
-        vk_regions[i].dstSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].dstSubresource.aspectMask);
+        vk_regions[i].dstSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].dstSubresource.aspectMask.value);
         vk_regions[i].dstSubresource.baseArrayLayer = pRegions[i].dstSubresource.baseArrayLayer;
         vk_regions[i].dstSubresource.layerCount = pRegions[i].dstSubresource.layerCount;
         vk_regions[i].dstSubresource.mipLevel = pRegions[i].dstSubresource.mipLevel;
@@ -126,7 +126,7 @@ bool CVulkanCommandBuffer::copyBufferToImage_impl(const buffer_t* srcBuffer, ima
         vk_regions[i].bufferOffset = pRegions[i].bufferOffset;
         vk_regions[i].bufferRowLength = pRegions[i].bufferRowLength;
         vk_regions[i].bufferImageHeight = pRegions[i].bufferImageHeight;
-        vk_regions[i].imageSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].imageSubresource.aspectMask);
+        vk_regions[i].imageSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].imageSubresource.aspectMask.value);
         vk_regions[i].imageSubresource.mipLevel = pRegions[i].imageSubresource.mipLevel;
         vk_regions[i].imageSubresource.baseArrayLayer = pRegions[i].imageSubresource.baseArrayLayer;
         vk_regions[i].imageSubresource.layerCount = pRegions[i].imageSubresource.layerCount;
@@ -157,7 +157,7 @@ bool CVulkanCommandBuffer::copyImageToBuffer_impl(const image_t* srcImage, asset
         vk_copyRegions[i].bufferOffset = static_cast<VkDeviceSize>(pRegions[i].bufferOffset);
         vk_copyRegions[i].bufferRowLength = pRegions[i].bufferRowLength;
         vk_copyRegions[i].bufferImageHeight = pRegions[i].bufferImageHeight;
-        vk_copyRegions[i].imageSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].imageSubresource.aspectMask);
+        vk_copyRegions[i].imageSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].imageSubresource.aspectMask.value);
         vk_copyRegions[i].imageSubresource.baseArrayLayer = pRegions[i].imageSubresource.baseArrayLayer;
         vk_copyRegions[i].imageSubresource.layerCount = pRegions[i].imageSubresource.layerCount;
         vk_copyRegions[i].imageSubresource.mipLevel = pRegions[i].imageSubresource.mipLevel;
@@ -188,7 +188,7 @@ bool CVulkanCommandBuffer::blitImage_impl(const image_t* srcImage, asset::IImage
 
     for (uint32_t i = 0u; i < regionCount; ++i)
     {
-        vk_blitRegions[i].srcSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].srcSubresource.aspectMask);
+        vk_blitRegions[i].srcSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].srcSubresource.aspectMask.value);
         vk_blitRegions[i].srcSubresource.mipLevel = pRegions[i].srcSubresource.mipLevel;
         vk_blitRegions[i].srcSubresource.baseArrayLayer = pRegions[i].srcSubresource.baseArrayLayer;
         vk_blitRegions[i].srcSubresource.layerCount = pRegions[i].srcSubresource.layerCount;
@@ -197,7 +197,7 @@ bool CVulkanCommandBuffer::blitImage_impl(const image_t* srcImage, asset::IImage
         vk_blitRegions[i].srcOffsets[0] = { static_cast<int32_t>(pRegions[i].srcOffsets[0].x), static_cast<int32_t>(pRegions[i].srcOffsets[0].y), static_cast<int32_t>(pRegions[i].srcOffsets[0].z) };
         vk_blitRegions[i].srcOffsets[1] = { static_cast<int32_t>(pRegions[i].srcOffsets[1].x), static_cast<int32_t>(pRegions[i].srcOffsets[1].y), static_cast<int32_t>(pRegions[i].srcOffsets[1].z) };
 
-        vk_blitRegions[i].dstSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].dstSubresource.aspectMask);
+        vk_blitRegions[i].dstSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].dstSubresource.aspectMask.value);
         vk_blitRegions[i].dstSubresource.mipLevel = pRegions[i].dstSubresource.mipLevel;
         vk_blitRegions[i].dstSubresource.baseArrayLayer = pRegions[i].dstSubresource.baseArrayLayer;
         vk_blitRegions[i].dstSubresource.layerCount = pRegions[i].dstSubresource.layerCount;
@@ -223,14 +223,14 @@ bool CVulkanCommandBuffer::resolveImage_impl(const image_t* srcImage, asset::IIm
     VkImageResolve vk_regions[MAX_COUNT];
     for (uint32_t i = 0u; i < regionCount; ++i)
     {
-        vk_regions[i].srcSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].srcSubresource.aspectMask);
+        vk_regions[i].srcSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].srcSubresource.aspectMask.value);
         vk_regions[i].srcSubresource.baseArrayLayer = pRegions[i].srcSubresource.baseArrayLayer;
         vk_regions[i].srcSubresource.layerCount = pRegions[i].srcSubresource.layerCount;
         vk_regions[i].srcSubresource.mipLevel = pRegions[i].srcSubresource.mipLevel;
 
         vk_regions[i].srcOffset = { static_cast<int32_t>(pRegions[i].srcOffset.x), static_cast<int32_t>(pRegions[i].srcOffset.y), static_cast<int32_t>(pRegions[i].srcOffset.z) };
 
-        vk_regions[i].dstSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].dstSubresource.aspectMask);
+        vk_regions[i].dstSubresource.aspectMask = static_cast<VkImageAspectFlags>(pRegions[i].dstSubresource.aspectMask.value);
         vk_regions[i].dstSubresource.baseArrayLayer = pRegions[i].dstSubresource.baseArrayLayer;
         vk_regions[i].dstSubresource.layerCount = pRegions[i].dstSubresource.layerCount;
         vk_regions[i].dstSubresource.mipLevel = pRegions[i].dstSubresource.mipLevel;
@@ -343,7 +343,7 @@ bool CVulkanCommandBuffer::waitEvents_impl(uint32_t eventCount, event_t* const* 
         vk_imageMemoryBarriers[i].srcQueueFamilyIndex = depInfo->imgBarriers[i].srcQueueFamilyIndex;
         vk_imageMemoryBarriers[i].dstQueueFamilyIndex = depInfo->imgBarriers[i].dstQueueFamilyIndex;
         vk_imageMemoryBarriers[i].image = IBackendObject::compatibility_cast<const CVulkanImage*>(depInfo->imgBarriers[i].image.get(), this)->getInternalObject();
-        vk_imageMemoryBarriers[i].subresourceRange.aspectMask = static_cast<VkImageAspectFlags>(depInfo->imgBarriers[i].subresourceRange.aspectMask);
+        vk_imageMemoryBarriers[i].subresourceRange.aspectMask = static_cast<VkImageAspectFlags>(depInfo->imgBarriers[i].subresourceRange.aspectMask.value);
         vk_imageMemoryBarriers[i].subresourceRange.baseMipLevel = depInfo->imgBarriers[i].subresourceRange.baseMipLevel;
         vk_imageMemoryBarriers[i].subresourceRange.levelCount = depInfo->imgBarriers[i].subresourceRange.levelCount;
         vk_imageMemoryBarriers[i].subresourceRange.baseArrayLayer = depInfo->imgBarriers[i].subresourceRange.baseArrayLayer;
@@ -415,7 +415,7 @@ bool CVulkanCommandBuffer::pipelineBarrier_impl(core::bitflag<asset::E_PIPELINE_
         vk_imageMemoryBarriers[i].srcQueueFamilyIndex = pImageMemoryBarriers[i].srcQueueFamilyIndex;
         vk_imageMemoryBarriers[i].dstQueueFamilyIndex = pImageMemoryBarriers[i].dstQueueFamilyIndex;
         vk_imageMemoryBarriers[i].image = IBackendObject::compatibility_cast<const CVulkanImage*>(pImageMemoryBarriers[i].image.get(), this)->getInternalObject();
-        vk_imageMemoryBarriers[i].subresourceRange.aspectMask = static_cast<VkImageAspectFlags>(pImageMemoryBarriers[i].subresourceRange.aspectMask);
+        vk_imageMemoryBarriers[i].subresourceRange.aspectMask = static_cast<VkImageAspectFlags>(pImageMemoryBarriers[i].subresourceRange.aspectMask.value);
         vk_imageMemoryBarriers[i].subresourceRange.baseMipLevel = pImageMemoryBarriers[i].subresourceRange.baseMipLevel;
         vk_imageMemoryBarriers[i].subresourceRange.levelCount = pImageMemoryBarriers[i].subresourceRange.levelCount;
         vk_imageMemoryBarriers[i].subresourceRange.baseArrayLayer = pImageMemoryBarriers[i].subresourceRange.baseArrayLayer;
@@ -559,7 +559,7 @@ bool CVulkanCommandBuffer::clearColorImage_impl(image_t* image, asset::IImage::E
 
     for (uint32_t i = 0u; i < rangeCount; ++i)
     {
-        vk_ranges[i].aspectMask = static_cast<VkImageAspectFlags>(pRanges[i].aspectMask);
+        vk_ranges[i].aspectMask = static_cast<VkImageAspectFlags>(pRanges[i].aspectMask.value);
         vk_ranges[i].baseMipLevel = pRanges[i].baseMipLevel;
         vk_ranges[i].levelCount = pRanges[i].layerCount;
         vk_ranges[i].baseArrayLayer = pRanges[i].baseArrayLayer;
@@ -588,7 +588,7 @@ bool CVulkanCommandBuffer::clearDepthStencilImage_impl(image_t* image, asset::II
 
     for (uint32_t i = 0u; i < rangeCount; ++i)
     {
-        vk_ranges[i].aspectMask = static_cast<VkImageAspectFlags>(pRanges[i].aspectMask);
+        vk_ranges[i].aspectMask = static_cast<VkImageAspectFlags>(pRanges[i].aspectMask.value);
         vk_ranges[i].baseMipLevel = pRanges[i].baseMipLevel;
         vk_ranges[i].levelCount = pRanges[i].layerCount;
         vk_ranges[i].baseArrayLayer = pRanges[i].baseArrayLayer;

--- a/src/nbl/video/CVulkanImageView.h
+++ b/src/nbl/video/CVulkanImageView.h
@@ -1,5 +1,5 @@
-#ifndef __NBL_C_VULKAN_IMAGE_VIEW_H_INCLUDED__
-#define __NBL_C_VULKAN_IMAGE_VIEW_H_INCLUDED__
+#ifndef _NBL_C_VULKAN_IMAGE_VIEW_H_INCLUDED_
+#define _NBL_C_VULKAN_IMAGE_VIEW_H_INCLUDED_
 
 #include "nbl/video/IGPUImageView.h"
 
@@ -13,21 +13,20 @@ class ILogicalDevice;
 
 class CVulkanImageView final : public IGPUImageView
 {
-public:
-    CVulkanImageView(core::smart_refctd_ptr<ILogicalDevice>&& logicalDevice,
-        SCreationParams&& _params, VkImageView imageView)
-        : IGPUImageView(std::move(logicalDevice), std::move(_params)), m_vkImageView(imageView)
-    {}
+    public:
+        CVulkanImageView(core::smart_refctd_ptr<ILogicalDevice>&& logicalDevice, SCreationParams&& _params, VkImageView imageView)
+            : IGPUImageView(std::move(logicalDevice), std::move(_params)), m_vkImageView(imageView)
+        {}
 
-    ~CVulkanImageView();
+        ~CVulkanImageView();
     
-	inline const void* getNativeHandle() const override {return &m_vkImageView;}
-    inline VkImageView getInternalObject() const { return m_vkImageView; }
+	    inline const void* getNativeHandle() const override {return &m_vkImageView;}
+        inline VkImageView getInternalObject() const { return m_vkImageView; }
 
-    void setObjectDebugName(const char* label) const override;
+        void setObjectDebugName(const char* label) const override;
 
-private:
-    VkImageView m_vkImageView;
+    private:
+        VkImageView m_vkImageView;
 };
 
 }

--- a/src/nbl/video/CVulkanLogicalDevice.h
+++ b/src/nbl/video/CVulkanLogicalDevice.h
@@ -984,8 +984,12 @@ protected:
 
     core::smart_refctd_ptr<IGPUImageView> createImageView_impl(IGPUImageView::SCreationParams&& params) override
     {
+        // Each pNext member of any structure (including this one) in the pNext chain must be either NULL or a pointer to a valid instance of VkImageViewASTCDecodeModeEXT, VkSamplerYcbcrConversionInfo, VkVideoProfileKHR, or VkVideoProfilesKHR
+        VkImageViewUsageCreateInfo vk_imageViewUsageInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO,nullptr };
+        vk_imageViewUsageInfo.usage = static_cast<VkImageUsageFlags>((params.subUsages.value ? params.subUsages:params.image->getCreationParameters().usage).value);
+
         VkImageViewCreateInfo vk_createInfo = { VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO };
-        vk_createInfo.pNext = nullptr; // Each pNext member of any structure (including this one) in the pNext chain must be either NULL or a pointer to a valid instance of VkImageViewASTCDecodeModeEXT, VkImageViewUsageCreateInfo, VkSamplerYcbcrConversionInfo, VkVideoProfileKHR, or VkVideoProfilesKHR
+        vk_createInfo.pNext = &vk_imageViewUsageInfo;
         vk_createInfo.flags = static_cast<VkImageViewCreateFlags>(params.flags);
 
         if (params.image->getAPIType() != EAT_VULKAN)
@@ -999,7 +1003,7 @@ protected:
         vk_createInfo.components.g = static_cast<VkComponentSwizzle>(params.components.g);
         vk_createInfo.components.b = static_cast<VkComponentSwizzle>(params.components.b);
         vk_createInfo.components.a = static_cast<VkComponentSwizzle>(params.components.a);
-        vk_createInfo.subresourceRange.aspectMask = static_cast<VkImageAspectFlags>(params.subresourceRange.aspectMask);
+        vk_createInfo.subresourceRange.aspectMask = static_cast<VkImageAspectFlags>(params.subresourceRange.aspectMask.value);
         vk_createInfo.subresourceRange.baseMipLevel = params.subresourceRange.baseMipLevel;
         vk_createInfo.subresourceRange.levelCount = params.subresourceRange.levelCount;
         vk_createInfo.subresourceRange.baseArrayLayer = params.subresourceRange.baseArrayLayer;

--- a/src/nbl/video/CVulkanPhysicalDevice.h
+++ b/src/nbl/video/CVulkanPhysicalDevice.h
@@ -28,70 +28,143 @@ public:
                 m_availableFeatureSet.insert(vk_extension.extensionName);
         }
 
-        // TODO: Query Properties/Features based on availability of extensions to avoid validation issues about "unknown VkStructureType"
+        // Basic stuff for constructing pNext chains
+        VkBaseInStructure* pNextTail;
+        auto setPNextChainTail = [&pNextTail](void* structure) -> void {pNextTail = reinterpret_cast<VkBaseInStructure*>(structure);};
+        auto addToPNextChain = [&pNextTail](void* structure) -> void
+        {
+            auto toAdd = reinterpret_cast<VkBaseInStructure*>(structure);
+            pNextTail->pNext = toAdd;
+            pNextTail = toAdd;
+        };
+        auto finalizePNextChain = [&pNextTail]() -> void
+        {
+            pNextTail->pNext = nullptr;
+        };
 
         // Get physical device's limits/properties
-        
-        // !! Always check the API version is >= 1.3 before using `vulkan13Properties`
-        VkPhysicalDeviceVulkan13Properties              vulkan13Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES, nullptr };
-        VkPhysicalDeviceMaintenance4Properties          maintanance4Properties = {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES, &vulkan13Properties};
-        VkPhysicalDeviceInlineUniformBlockProperties    inlineUniformBlockProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES, &maintanance4Properties };
-        VkPhysicalDeviceSubgroupSizeControlProperties   subgroupSizeControlProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES, &inlineUniformBlockProperties };
-        VkPhysicalDeviceTexelBufferAlignmentProperties  texelBufferAlignmentProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES, &subgroupSizeControlProperties };
-
-        // !! Always check the API version is >= 1.2 before using `vulkan12Properties`
-        VkPhysicalDeviceVulkan12Properties                  vulkan12Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES, &texelBufferAlignmentProperties };
-        VkPhysicalDeviceDriverProperties                    driverProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES, &vulkan12Properties };
-        VkPhysicalDeviceFloatControlsProperties             floatControlsProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES, &driverProperties };
-        VkPhysicalDeviceDescriptorIndexingProperties        descriptorIndexingProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES, &floatControlsProperties };
-        VkPhysicalDeviceDepthStencilResolveProperties       depthStencilResolveProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES, &descriptorIndexingProperties };
-        VkPhysicalDeviceSamplerFilterMinmaxProperties       samplerFilterMinmaxProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES, &depthStencilResolveProperties };
-        VkPhysicalDeviceTimelineSemaphoreProperties         timelineSemaphoreProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES, &samplerFilterMinmaxProperties };
-        VkPhysicalDeviceLineRasterizationPropertiesEXT      lineRasterizationPropertiesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT, &timelineSemaphoreProperties };
-        VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT vertexAttributeDivisorPropertiesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT, &lineRasterizationPropertiesEXT };
-        VkPhysicalDeviceSubpassShadingPropertiesHUAWEI      subpassShadingPropertiesHUAWEI = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI, &vertexAttributeDivisorPropertiesEXT };
-        VkPhysicalDeviceShaderIntegerDotProductProperties   shaderIntegerDotProductProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES, &subpassShadingPropertiesHUAWEI };
-
-        // !! Our minimum supported Vulkan version is 1.1, no need to check anything before using `vulkan11Properties`
-        VkPhysicalDeviceVulkan11Properties vulkan11Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES, &shaderIntegerDotProductProperties };
-
-        // Extensions
-        VkPhysicalDeviceExternalMemoryHostPropertiesEXT externalMemoryHostPropertiesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT, &vulkan11Properties };
-        VkPhysicalDeviceConservativeRasterizationPropertiesEXT conservativeRasterizationProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT, &externalMemoryHostPropertiesEXT };
-        VkPhysicalDeviceShaderCoreProperties2AMD shaderCoreProperties2AMD = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD, &conservativeRasterizationProperties };
-        VkPhysicalDeviceShaderSMBuiltinsPropertiesNV shaderSMBuiltinsProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV, &shaderCoreProperties2AMD };
-        VkPhysicalDeviceCooperativeMatrixPropertiesNV cooperativeMatrixProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV, &shaderSMBuiltinsProperties };
-        VkPhysicalDeviceSampleLocationsPropertiesEXT sampleLocationsProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT, &cooperativeMatrixProperties };
-        VkPhysicalDevicePCIBusInfoPropertiesEXT PCIBusInfoProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT, &sampleLocationsProperties };
-        VkPhysicalDeviceDiscardRectanglePropertiesEXT discardRectangleProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT, &PCIBusInfoProperties };
-        VkPhysicalDeviceRayTracingPipelinePropertiesKHR rayTracingPipelineProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR, &discardRectangleProperties };
-        VkPhysicalDeviceAccelerationStructurePropertiesKHR accelerationStructureProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR, &rayTracingPipelineProperties };
-        VkPhysicalDeviceFragmentDensityMapPropertiesEXT fragmentDensityMapProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT, &accelerationStructureProperties };
-        VkPhysicalDeviceFragmentDensityMap2PropertiesEXT fragmentDensityMap2Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT, &fragmentDensityMapProperties };
         {
-            //! Basically remove a query struct from the chain if it's not supported by vulkan version:
-            //! We need to do these only for `vulkan12Properties` and `vulkan13Properties` since our minimum is Vulkan 1.1 and these two are only provided by VK_VESION_1_2/1_3 (not any extensions) 
-            //! Other structures are provided by VK_XX_EXTENSION or VK_VERSION_XX so no need to check whether we need to remove them from query chain
-            //! This is only written for convenience to avoid getting validation errors otherwise vulkan will just skip any strutctures it doesn't recognize
-            if(instanceApiVersion < VK_MAKE_API_VERSION(0, 1, 2, 0))
-            {
-                assert(driverProperties.pNext == &vulkan12Properties);
-                driverProperties.pNext = vulkan12Properties.pNext;
-            }
-            if(instanceApiVersion < VK_MAKE_API_VERSION(0, 1, 3, 0))
-            {
-                assert(maintanance4Properties.pNext == &vulkan13Properties);
-                maintanance4Properties.pNext = vulkan13Properties.pNext;
-            }
-
-
             VkPhysicalDeviceProperties2 deviceProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2 };
-            deviceProperties.pNext = &fragmentDensityMap2Properties;
+            setPNextChainTail(&deviceProperties);
+            // !! Our minimum supported Vulkan version is 1.1, no need to check anything before using `vulkan11Properties`
+            VkPhysicalDeviceVulkan11Properties                      vulkan11Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES };
+            addToPNextChain(&vulkan11Properties);
+            //! Declare all the property structs before so they don't go out of scope
+            //! Provided by Vk 1.2
+            VkPhysicalDeviceVulkan12Properties                      vulkan12Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES };
+            VkPhysicalDeviceDriverProperties                        driverProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES };
+            VkPhysicalDeviceFloatControlsProperties                 floatControlsProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES };
+            VkPhysicalDeviceDescriptorIndexingProperties            descriptorIndexingProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES };
+            VkPhysicalDeviceDepthStencilResolveProperties           depthStencilResolveProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES };
+            VkPhysicalDeviceSamplerFilterMinmaxProperties           samplerFilterMinmaxProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES };
+            VkPhysicalDeviceTimelineSemaphoreProperties             timelineSemaphoreProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES };
+            //! Provided by Vk 1.3
+            VkPhysicalDeviceVulkan13Properties                      vulkan13Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES };
+            VkPhysicalDeviceMaintenance4Properties                  maintanance4Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES };
+            VkPhysicalDeviceInlineUniformBlockProperties            inlineUniformBlockProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES };
+            VkPhysicalDeviceSubgroupSizeControlProperties           subgroupSizeControlProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES };
+            VkPhysicalDeviceTexelBufferAlignmentProperties          texelBufferAlignmentProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES };
+            VkPhysicalDeviceShaderIntegerDotProductProperties       shaderIntegerDotProductProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES };
+            //! Extensions
+            VkPhysicalDeviceConservativeRasterizationPropertiesEXT  conservativeRasterizationProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT };
+            VkPhysicalDeviceDiscardRectanglePropertiesEXT           discardRectangleProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT };
+            VkPhysicalDeviceExternalMemoryHostPropertiesEXT         externalMemoryHostPropertiesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT };
+            VkPhysicalDevicePCIBusInfoPropertiesEXT                 PCIBusInfoProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT };
+            VkPhysicalDeviceSampleLocationsPropertiesEXT            sampleLocationsProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT };
+            VkPhysicalDeviceCooperativeMatrixPropertiesNV           cooperativeMatrixProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV };
+            VkPhysicalDeviceAccelerationStructurePropertiesKHR      accelerationStructureProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR };
+            VkPhysicalDeviceRayTracingPipelinePropertiesKHR         rayTracingPipelineProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR };
+            VkPhysicalDeviceFragmentDensityMapPropertiesEXT         fragmentDensityMapProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT };
+            VkPhysicalDeviceFragmentDensityMap2PropertiesEXT        fragmentDensityMap2Properties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT };
+            VkPhysicalDeviceLineRasterizationPropertiesEXT          lineRasterizationPropertiesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT };
+            VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT     vertexAttributeDivisorPropertiesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT };
+            VkPhysicalDeviceSubpassShadingPropertiesHUAWEI          subpassShadingPropertiesHUAWEI = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI };
+            VkPhysicalDeviceShaderSMBuiltinsPropertiesNV            shaderSMBuiltinsProperties = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV };
+            VkPhysicalDeviceShaderCoreProperties2AMD                shaderCoreProperties2AMD = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD };
+            //! This is only written for convenience to avoid getting validation errors otherwise vulkan will just skip any strutctures it doesn't recognize
+            if (instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0))
+            {
+                addToPNextChain(&vulkan12Properties);
+                addToPNextChain(&driverProperties);
+                addToPNextChain(&floatControlsProperties);
+                addToPNextChain(&descriptorIndexingProperties);
+                addToPNextChain(&depthStencilResolveProperties);
+                addToPNextChain(&samplerFilterMinmaxProperties);
+                addToPNextChain(&timelineSemaphoreProperties);
+            }
+            else
+            {
+                assert(isExtensionSupported(VK_KHR_DRIVER_PROPERTIES_EXTENSION_NAME));
+                addToPNextChain(&driverProperties);
+                if (isExtensionSupported(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME))
+                    addToPNextChain(&floatControlsProperties);
+                if (isExtensionSupported(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME))
+                    addToPNextChain(&descriptorIndexingProperties);
+                if (isExtensionSupported(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME))
+                    addToPNextChain(&depthStencilResolveProperties);
+                if (isExtensionSupported(VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME))
+                    addToPNextChain(&samplerFilterMinmaxProperties);
+                if (isExtensionSupported(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME))
+                    addToPNextChain(&timelineSemaphoreProperties);
+            }
+            if (instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0))
+            {
+                addToPNextChain(&vulkan13Properties); // old validation layers might complain about this struct in pNext, all is fine
+                addToPNextChain(&maintanance4Properties); // old validation layers might complain about this struct in pNext, all is fine
+                addToPNextChain(&inlineUniformBlockProperties);
+                addToPNextChain(&subgroupSizeControlProperties);
+                addToPNextChain(&texelBufferAlignmentProperties);
+                addToPNextChain(&shaderIntegerDotProductProperties); // old validation layers might complain about this struct in pNext, all is fine
+            }
+            else
+            {
+                if (isExtensionSupported(VK_KHR_MAINTENANCE_4_EXTENSION_NAME))
+                    addToPNextChain(&maintanance4Properties);
+                if (isExtensionSupported(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME))
+                    addToPNextChain(&inlineUniformBlockProperties);
+                if (isExtensionSupported(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME))
+                    addToPNextChain(&subgroupSizeControlProperties);
+                if (isExtensionSupported(VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME))
+                    addToPNextChain(&texelBufferAlignmentProperties);
+                if (isExtensionSupported(VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME))
+                    addToPNextChain(&shaderIntegerDotProductProperties);
+            }
+            if (isExtensionSupported(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME))
+                addToPNextChain(&conservativeRasterizationProperties);
+            if (isExtensionSupported(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME))
+                addToPNextChain(&discardRectangleProperties);
+            if (isExtensionSupported(VK_EXT_EXTERNAL_MEMORY_HOST_EXTENSION_NAME))
+                addToPNextChain(&externalMemoryHostPropertiesEXT);
+            if (isExtensionSupported(VK_EXT_PCI_BUS_INFO_EXTENSION_NAME))
+                addToPNextChain(&PCIBusInfoProperties);
+            if (isExtensionSupported(VK_EXT_SAMPLE_LOCATIONS_EXTENSION_NAME))
+                addToPNextChain(&sampleLocationsProperties);
+            if (isExtensionSupported(VK_NV_COOPERATIVE_MATRIX_EXTENSION_NAME))
+                addToPNextChain(&cooperativeMatrixProperties);
+            if (isExtensionSupported(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME))
+                addToPNextChain(&accelerationStructureProperties);
+            if (isExtensionSupported(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME))
+                addToPNextChain(&rayTracingPipelineProperties);
+            if (isExtensionSupported(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME))
+                addToPNextChain(&fragmentDensityMapProperties);
+            if (isExtensionSupported(VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME))
+                addToPNextChain(&fragmentDensityMap2Properties);
+            if (isExtensionSupported(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME))
+                addToPNextChain(&lineRasterizationPropertiesEXT);
+            if (isExtensionSupported(VK_EXT_VERTEX_ATTRIBUTE_DIVISOR_EXTENSION_NAME))
+                addToPNextChain(&vertexAttributeDivisorPropertiesEXT);
+            if (isExtensionSupported(VK_HUAWEI_SUBPASS_SHADING_EXTENSION_NAME))
+                addToPNextChain(&subpassShadingPropertiesHUAWEI);
+            if (isExtensionSupported(VK_NV_SHADER_SM_BUILTINS_EXTENSION_NAME))
+                addToPNextChain(&shaderSMBuiltinsProperties);
+            if (isExtensionSupported(VK_AMD_SHADER_CORE_PROPERTIES_2_EXTENSION_NAME))
+                addToPNextChain(&shaderCoreProperties2AMD);
+            // call
+            finalizePNextChain();
             vkGetPhysicalDeviceProperties2(m_vkPhysicalDevice, &deviceProperties);
 
-            /* Vulkan 1.0 Core  */
-            
-            uint32_t apiVersion = std::min(instanceApiVersion, deviceProperties.properties.apiVersion);
+            //! Vulkan 1.0 Core
+            const uint32_t apiVersion = std::min(instanceApiVersion,deviceProperties.properties.apiVersion);
             assert(apiVersion >= MinimumVulkanApiVersion);
             m_properties.apiVersion.major = VK_API_VERSION_MAJOR(apiVersion);
             m_properties.apiVersion.minor = VK_API_VERSION_MINOR(apiVersion);
@@ -102,20 +175,20 @@ public:
             m_properties.deviceID = deviceProperties.properties.deviceID;
             switch(deviceProperties.properties.deviceType)
             {
-            case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
-                m_properties.deviceType = E_TYPE::ET_INTEGRATED_GPU;
-                break;
-            case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
-                m_properties.deviceType = E_TYPE::ET_DISCRETE_GPU;
-                break;
-            case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
-                m_properties.deviceType = E_TYPE::ET_VIRTUAL_GPU;
-                break;
-            case VK_PHYSICAL_DEVICE_TYPE_CPU:
-                m_properties.deviceType = E_TYPE::ET_CPU;
-                break;
-            default:
-                m_properties.deviceType = E_TYPE::ET_UNKNOWN;
+                case VK_PHYSICAL_DEVICE_TYPE_INTEGRATED_GPU:
+                    m_properties.deviceType = E_TYPE::ET_INTEGRATED_GPU;
+                    break;
+                case VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU:
+                    m_properties.deviceType = E_TYPE::ET_DISCRETE_GPU;
+                    break;
+                case VK_PHYSICAL_DEVICE_TYPE_VIRTUAL_GPU:
+                    m_properties.deviceType = E_TYPE::ET_VIRTUAL_GPU;
+                    break;
+                case VK_PHYSICAL_DEVICE_TYPE_CPU:
+                    m_properties.deviceType = E_TYPE::ET_CPU;
+                    break;
+                default:
+                    m_properties.deviceType = E_TYPE::ET_UNKNOWN;
             }
             memcpy(m_properties.deviceName, deviceProperties.properties.deviceName, VK_MAX_PHYSICAL_DEVICE_NAME_SIZE);
             memcpy(m_properties.pipelineCacheUUID, deviceProperties.properties.pipelineCacheUUID, VK_UUID_SIZE);
@@ -264,7 +337,7 @@ public:
             bool isAMDGPU = (m_properties.driverID == E_DRIVER_ID::EDI_AMD_OPEN_SOURCE || m_properties.driverID == E_DRIVER_ID::EDI_AMD_PROPRIETARY);
             bool isNVIDIAGPU = (m_properties.driverID == E_DRIVER_ID::EDI_NVIDIA_PROPRIETARY);
 
-            if(isExtensionSupported(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME))
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_KHR_SHADER_FLOAT_CONTROLS_EXTENSION_NAME))
             {
                 m_properties.limits.shaderSignedZeroInfNanPreserveFloat16 = floatControlsProperties.shaderSignedZeroInfNanPreserveFloat16 ? SPhysicalDeviceLimits::ETB_TRUE : SPhysicalDeviceLimits::ETB_FALSE;
                 m_properties.limits.shaderSignedZeroInfNanPreserveFloat32 = floatControlsProperties.shaderSignedZeroInfNanPreserveFloat32 ? SPhysicalDeviceLimits::ETB_TRUE : SPhysicalDeviceLimits::ETB_FALSE;
@@ -283,7 +356,7 @@ public:
                 m_properties.limits.shaderRoundingModeRTZFloat64 = floatControlsProperties.shaderRoundingModeRTZFloat64 ? SPhysicalDeviceLimits::ETB_TRUE : SPhysicalDeviceLimits::ETB_FALSE;
             }
             
-            if(isExtensionSupported(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME))
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME))
             {
                 m_properties.limits.maxUpdateAfterBindDescriptorsInAllPools                 = descriptorIndexingProperties.maxUpdateAfterBindDescriptorsInAllPools;
                 m_properties.limits.shaderUniformBufferArrayNonUniformIndexingNative        = descriptorIndexingProperties.shaderUniformBufferArrayNonUniformIndexingNative;
@@ -310,19 +383,19 @@ public:
                 m_properties.limits.maxDescriptorSetUpdateAfterBindInputAttachments         = descriptorIndexingProperties.maxDescriptorSetUpdateAfterBindInputAttachments;
             }
 
-            if(isExtensionSupported(VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME))
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME))
             {
                 m_properties.limits.filterMinmaxSingleComponentFormats = samplerFilterMinmaxProperties.filterMinmaxSingleComponentFormats;
                 m_properties.limits.filterMinmaxImageComponentMapping = samplerFilterMinmaxProperties.filterMinmaxImageComponentMapping;
             }
 
             /* Vulkan 1.3 Core  */
-            if(isExtensionSupported(VK_KHR_MAINTENANCE_4_EXTENSION_NAME))
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_KHR_MAINTENANCE_4_EXTENSION_NAME))
                 m_properties.limits.maxBufferSize = maintanance4Properties.maxBufferSize;
             else
                 m_properties.limits.maxBufferSize = vulkan11Properties.maxMemoryAllocationSize;
 
-            if(isExtensionSupported(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME))
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME))
             {
                 m_properties.limits.minSubgroupSize = subgroupSizeControlProperties.minSubgroupSize;
                 m_properties.limits.maxSubgroupSize = subgroupSizeControlProperties.maxSubgroupSize;
@@ -334,7 +407,7 @@ public:
                 getMinMaxSubgroupSizeFromDriverID(m_properties.driverID, m_properties.limits.minSubgroupSize, m_properties.limits.maxSubgroupSize);
             }
 
-            if (isExtensionSupported(VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME))
+            if (instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME))
             {
                 m_properties.limits.storageTexelBufferOffsetAlignmentBytes = texelBufferAlignmentProperties.storageTexelBufferOffsetAlignmentBytes;
                 m_properties.limits.uniformTexelBufferOffsetAlignmentBytes = texelBufferAlignmentProperties.uniformTexelBufferOffsetAlignmentBytes;
@@ -345,7 +418,42 @@ public:
                 m_properties.limits.uniformTexelBufferOffsetAlignmentBytes = deviceProperties.properties.limits.minTexelBufferOffsetAlignment;
             }
 
-            /* Extensions */
+            if (instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME))
+            {
+                m_properties.limits.integerDotProduct8BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct8BitUnsignedAccelerated;
+                m_properties.limits.integerDotProduct8BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct8BitSignedAccelerated;
+                m_properties.limits.integerDotProduct8BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct8BitMixedSignednessAccelerated;
+                m_properties.limits.integerDotProduct4x8BitPackedUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct4x8BitPackedUnsignedAccelerated;
+                m_properties.limits.integerDotProduct4x8BitPackedSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct4x8BitPackedSignedAccelerated;
+                m_properties.limits.integerDotProduct4x8BitPackedMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct4x8BitPackedMixedSignednessAccelerated;
+                m_properties.limits.integerDotProduct16BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct16BitUnsignedAccelerated;
+                m_properties.limits.integerDotProduct16BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct16BitSignedAccelerated;
+                m_properties.limits.integerDotProduct16BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct16BitMixedSignednessAccelerated;
+                m_properties.limits.integerDotProduct32BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct32BitUnsignedAccelerated;
+                m_properties.limits.integerDotProduct32BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct32BitSignedAccelerated;
+                m_properties.limits.integerDotProduct32BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct32BitMixedSignednessAccelerated;
+                m_properties.limits.integerDotProduct64BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct64BitUnsignedAccelerated;
+                m_properties.limits.integerDotProduct64BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct64BitSignedAccelerated;
+                m_properties.limits.integerDotProduct64BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct64BitMixedSignednessAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating8BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating8BitUnsignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating8BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating8BitSignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating16BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating16BitUnsignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating16BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating16BitSignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating32BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating32BitUnsignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating32BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating32BitSignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating64BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating64BitUnsignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating64BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating64BitSignedAccelerated;
+                m_properties.limits.integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated;
+            }
+
+
+            //! Extensions
             
             /* ConservativeRasterizationPropertiesEXT */
             if (isExtensionSupported(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME))
@@ -454,43 +562,7 @@ public:
                 m_properties.limits.maxSubpassShadingWorkgroupSizeAspectRatio = subpassShadingPropertiesHUAWEI.maxSubpassShadingWorkgroupSizeAspectRatio;
             }
 
-            /* VkPhysicalDeviceShaderIntegerDotProductProperties */
-            if (isExtensionSupported(VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME))
-            {
-                m_properties.limits.integerDotProduct8BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct8BitUnsignedAccelerated;
-                m_properties.limits.integerDotProduct8BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct8BitSignedAccelerated;
-                m_properties.limits.integerDotProduct8BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct8BitMixedSignednessAccelerated;
-                m_properties.limits.integerDotProduct4x8BitPackedUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct4x8BitPackedUnsignedAccelerated;
-                m_properties.limits.integerDotProduct4x8BitPackedSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct4x8BitPackedSignedAccelerated;
-                m_properties.limits.integerDotProduct4x8BitPackedMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct4x8BitPackedMixedSignednessAccelerated;
-                m_properties.limits.integerDotProduct16BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct16BitUnsignedAccelerated;
-                m_properties.limits.integerDotProduct16BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct16BitSignedAccelerated;
-                m_properties.limits.integerDotProduct16BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct16BitMixedSignednessAccelerated;
-                m_properties.limits.integerDotProduct32BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct32BitUnsignedAccelerated;
-                m_properties.limits.integerDotProduct32BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct32BitSignedAccelerated;
-                m_properties.limits.integerDotProduct32BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct32BitMixedSignednessAccelerated;
-                m_properties.limits.integerDotProduct64BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct64BitUnsignedAccelerated;
-                m_properties.limits.integerDotProduct64BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProduct64BitSignedAccelerated;
-                m_properties.limits.integerDotProduct64BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProduct64BitMixedSignednessAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating8BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating8BitUnsignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating8BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating8BitSignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating8BitMixedSignednessAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating4x8BitPackedUnsignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating4x8BitPackedSignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating4x8BitPackedMixedSignednessAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating16BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating16BitUnsignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating16BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating16BitSignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating16BitMixedSignednessAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating32BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating32BitUnsignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating32BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating32BitSignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating32BitMixedSignednessAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating64BitUnsignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating64BitUnsignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating64BitSignedAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating64BitSignedAccelerated;
-                m_properties.limits.integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated = shaderIntegerDotProductProperties.integerDotProductAccumulatingSaturating64BitMixedSignednessAccelerated;
-            }
-
-            /* Nabla */
-            
+            //! Nabla
             if (isExtensionSupported(VK_NV_SHADER_SM_BUILTINS_EXTENSION_NAME))
                 m_properties.limits.computeUnits = shaderSMBuiltinsProperties.shaderSMCount;
             else if(isExtensionSupported(VK_AMD_SHADER_CORE_PROPERTIES_2_EXTENSION_NAME))
@@ -554,85 +626,226 @@ public:
         // VK_EXT_descriptor_indexing              descriptorIndexing
         // VK_EXT_sampler_filter_minmax            samplerFilterMinmax
         // VK_EXT_shader_viewport_index_layer      shaderOutputViewportIndex, shaderOutputLayer
-    
-
-        // !! Our minimum supported Vulkan version is 1.1, no need to check anything before using `vulkan11Features`
-        VkPhysicalDeviceVulkan12Features vulkan12Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, nullptr };
-        VkPhysicalDeviceVulkan11Features vulkan11Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES, &vulkan12Features };
 
         // Extensions
-        VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT                 texelBufferAlignmentFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT, &vulkan11Features };
-        VkPhysicalDeviceHostQueryResetFeatures                          hostQueryResetFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES, &texelBufferAlignmentFeatures };
-        VkPhysicalDeviceImageRobustnessFeatures                         imageRobustnessFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES, &hostQueryResetFeatures };
-        VkPhysicalDevicePipelineCreationCacheControlFeatures            pipelineCreationCacheControlFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES, &imageRobustnessFeatures };
-        VkPhysicalDeviceColorWriteEnableFeaturesEXT                     colorWriteEnableFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT, &pipelineCreationCacheControlFeatures };
-        VkPhysicalDeviceConditionalRenderingFeaturesEXT                 conditionalRenderingFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT, &colorWriteEnableFeatures };
-        VkPhysicalDeviceDeviceMemoryReportFeaturesEXT                   deviceMemoryReportFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT, &conditionalRenderingFeatures };
-        VkPhysicalDeviceFragmentDensityMapFeaturesEXT                   fragmentDensityMapFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT, &deviceMemoryReportFeatures };
-        VkPhysicalDeviceFragmentDensityMap2FeaturesEXT                  fragmentDensityMap2Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT, &fragmentDensityMapFeatures };
-        VkPhysicalDeviceInlineUniformBlockFeatures                      inlineUniformBlockFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES, &fragmentDensityMap2Features };
-        VkPhysicalDeviceLineRasterizationFeaturesEXT                    lineRasterizationFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT, &inlineUniformBlockFeatures };
-        VkPhysicalDeviceMemoryPriorityFeaturesEXT                       memoryPriorityFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT, &lineRasterizationFeatures };
-        VkPhysicalDeviceRobustness2FeaturesEXT                          robustness2Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT, &memoryPriorityFeatures };
-        VkPhysicalDevicePerformanceQueryFeaturesKHR                     performanceQueryFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR, &robustness2Features };
-        VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR         pipelineExecutablePropertiesFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR, &performanceQueryFeatures };
-        VkPhysicalDeviceMaintenance4Features                            maintenance4Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES, &pipelineExecutablePropertiesFeatures };
-        VkPhysicalDeviceCoherentMemoryFeaturesAMD                       coherentMemoryFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD, &maintenance4Features };
-        VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR                  globalPriorityFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR, &coherentMemoryFeatures };
-        VkPhysicalDeviceCoverageReductionModeFeaturesNV                 coverageReductionModeFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV, &globalPriorityFeatures };
-        VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV               deviceGeneratedCommandsFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV, &coverageReductionModeFeatures };
-        VkPhysicalDeviceMeshShaderFeaturesNV                            meshShaderFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV, &deviceGeneratedCommandsFeatures };
-        VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV            representativeFragmentTestFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV, &meshShaderFeatures };
-        VkPhysicalDeviceShaderImageFootprintFeaturesNV                  shaderImageFootprintFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV, &representativeFragmentTestFeatures };
-        VkPhysicalDeviceComputeShaderDerivativesFeaturesNV              computeShaderDerivativesFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV, &shaderImageFootprintFeatures };
-        VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR        workgroupMemoryExplicitLayout = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR, &computeShaderDerivativesFeatures };
-        VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR     subgroupUniformControlFlowFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR, &workgroupMemoryExplicitLayout };
-        VkPhysicalDeviceShaderClockFeaturesKHR                          shaderClockFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR, &subgroupUniformControlFlowFeatures };
-        VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL            intelShaderIntegerFunctions2 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL, &shaderClockFeatures };
-        VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT               shaderImageAtomicInt64Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT, &intelShaderIntegerFunctions2 };
-        VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT                   shaderAtomicFloat2Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT, &shaderImageAtomicInt64Features };
-        VkPhysicalDeviceShaderAtomicFloatFeaturesEXT                    shaderAtomicFloatFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT, &shaderAtomicFloat2Features };
-        VkPhysicalDeviceIndexTypeUint8FeaturesEXT                       indexTypeUint8Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT, &shaderAtomicFloatFeatures };
-        VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM   rasterizationOrderAttachmentAccessFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_ARM, &indexTypeUint8Features };
-        VkPhysicalDeviceShaderIntegerDotProductFeatures                 shaderIntegerDotProductFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES, &rasterizationOrderAttachmentAccessFeatures };
-        VkPhysicalDeviceShaderTerminateInvocationFeatures               shaderTerminateInvocationFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES, &shaderIntegerDotProductFeatures };
-        VkPhysicalDeviceScalarBlockLayoutFeatures                       scalarBlockLayoutFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES, &shaderTerminateInvocationFeatures };
-        VkPhysicalDeviceVulkanMemoryModelFeatures                       vulkanMemoryModelFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES, &scalarBlockLayoutFeatures };
-        VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures             separateDepthStencilLayoutsFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES, &vulkanMemoryModelFeatures };
-        VkPhysicalDeviceUniformBufferStandardLayoutFeatures             uniformBufferStandardLayoutFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES, &separateDepthStencilLayoutsFeatures };
-        VkPhysicalDeviceRayTracingMotionBlurFeaturesNV                  rayTracingMotionBlurFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV, &uniformBufferStandardLayoutFeatures };
-        VkPhysicalDeviceSubgroupSizeControlFeaturesEXT                  subgroupSizeControlFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT, &rayTracingMotionBlurFeatures };
-        VkPhysicalDeviceShaderFloat16Int8Features                       shaderFloat16Int8Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR, &subgroupSizeControlFeatures };
-        VkPhysicalDeviceDescriptorIndexingFeaturesEXT                   descriptorIndexingFeaturesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT, &shaderFloat16Int8Features };
-        VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR          shaderSubgroupExtendedTypesFeaturesKHR = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES_KHR, &descriptorIndexingFeaturesEXT };
-        VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT       shaderDemoteToHelperInvocationFeaturesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT, &shaderSubgroupExtendedTypesFeaturesKHR };
-        VkPhysicalDeviceASTCDecodeFeaturesEXT                           astcDecodeFeaturesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT, &shaderDemoteToHelperInvocationFeaturesEXT };
-        VkPhysicalDeviceShaderAtomicInt64FeaturesKHR                    shaderAtomicInt64FeaturesKHR = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR, &astcDecodeFeaturesEXT };
-        VkPhysicalDevice8BitStorageFeaturesKHR                          _8BitStorageFeaturesKHR = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR, &shaderAtomicInt64FeaturesKHR };
-        VkPhysicalDeviceShaderSMBuiltinsFeaturesNV                      shaderSMBuiltinsFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV, &_8BitStorageFeaturesKHR };
-        VkPhysicalDeviceCooperativeMatrixFeaturesNV                     cooperativeMatrixFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV, &shaderSMBuiltinsFeatures };
-        VkPhysicalDeviceRayTracingPipelineFeaturesKHR                   rayTracingPipelineFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR, &cooperativeMatrixFeatures };
-        VkPhysicalDeviceAccelerationStructureFeaturesKHR                accelerationFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR, &rayTracingPipelineFeatures };
-        VkPhysicalDeviceRayQueryFeaturesKHR                             rayQueryFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR, &accelerationFeatures };
-        VkPhysicalDeviceBufferDeviceAddressFeaturesKHR                  bufferDeviceAddressFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR, &rayQueryFeatures };
-        VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT              fragmentShaderInterlockFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT, &bufferDeviceAddressFeatures };
         {
-            //! Basically remove a query struct from the chain if it's not supported by vulkan version:
-            //! We need to do these only for `vulkan12Features` since our minimum is Vulkan 1.1 and this is only provided by VK_VESION_1_2 (not any extensions) 
-            //! Other structures are provided by VK_XX_EXTENSION or VK_VERSION_XX so no need to check whether we need to remove them from query chain
-            //! This is only written for convenience to avoid getting validation errors otherwise vulkan will just skip any strutctures it doesn't recognize
-            if(instanceApiVersion < VK_MAKE_API_VERSION(0, 1, 2, 0))
-            {
-                assert(vulkan11Features.pNext == &vulkan12Features);
-                vulkan11Features.pNext = vulkan12Features.pNext;
-            }
-
             VkPhysicalDeviceFeatures2 deviceFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2 };
-            deviceFeatures.pNext = &fragmentShaderInterlockFeatures;
-            vkGetPhysicalDeviceFeatures2(m_vkPhysicalDevice, &deviceFeatures);
-            const auto& features = deviceFeatures.features;
+            setPNextChainTail(&deviceFeatures);
+            // !! Our minimum supported Vulkan version is 1.1, no need to check anything before using `vulkan11Features`
+            VkPhysicalDeviceVulkan11Features                                vulkan11Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES };
+            addToPNextChain(&vulkan11Features);
+            //! Declare all the property structs before so they don't go out of scope
+            //! Provided by Vk 1.2
+            VkPhysicalDeviceVulkan12Features                                vulkan12Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES };
+            VkPhysicalDeviceDescriptorIndexingFeaturesEXT                   descriptorIndexingFeaturesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES_EXT };
+            VkPhysicalDeviceShaderSubgroupExtendedTypesFeaturesKHR          shaderSubgroupExtendedTypesFeaturesKHR = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES_KHR };
+            VkPhysicalDeviceHostQueryResetFeatures                          hostQueryResetFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES };
+            VkPhysicalDeviceScalarBlockLayoutFeatures                       scalarBlockLayoutFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES };
+            VkPhysicalDeviceVulkanMemoryModelFeatures                       vulkanMemoryModelFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES };
+            VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures             separateDepthStencilLayoutsFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES };
+            VkPhysicalDeviceUniformBufferStandardLayoutFeatures             uniformBufferStandardLayoutFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES }; // 922
+            VkPhysicalDevice8BitStorageFeaturesKHR                          _8BitStorageFeaturesKHR = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES_KHR }; // 1232
+            VkPhysicalDeviceShaderAtomicInt64FeaturesKHR                    shaderAtomicInt64FeaturesKHR = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES_KHR };
+            VkPhysicalDeviceShaderFloat16Int8Features                       shaderFloat16Int8Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES_KHR };
+            //! Provided by Vk 1.3
+            VkPhysicalDeviceVulkan13Features                                vulkan13Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES };
+            VkPhysicalDeviceSubgroupSizeControlFeaturesEXT                  subgroupSizeControlFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES_EXT };
+            VkPhysicalDeviceShaderTerminateInvocationFeatures               shaderTerminateInvocationFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES };
+            VkPhysicalDeviceShaderIntegerDotProductFeatures                 shaderIntegerDotProductFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES };
+            VkPhysicalDeviceBufferDeviceAddressFeaturesKHR                  bufferDeviceAddressFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_KHR };
+            VkPhysicalDeviceImageRobustnessFeatures                         imageRobustnessFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES };
+            VkPhysicalDevicePipelineCreationCacheControlFeatures            pipelineCreationCacheControlFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES };
+            VkPhysicalDeviceInlineUniformBlockFeatures                      inlineUniformBlockFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES };
+            VkPhysicalDeviceShaderDemoteToHelperInvocationFeaturesEXT       shaderDemoteToHelperInvocationFeaturesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES_EXT };
+            VkPhysicalDeviceMaintenance4Features                            maintenance4Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES };
+            //! Extensions
+            VkPhysicalDeviceCooperativeMatrixFeaturesNV                     cooperativeMatrixFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV };
+            VkPhysicalDeviceRayQueryFeaturesKHR                             rayQueryFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR };
+            VkPhysicalDeviceAccelerationStructureFeaturesKHR                accelerationFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR };
+            VkPhysicalDeviceRayTracingPipelineFeaturesKHR                   rayTracingPipelineFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR };
+            VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT              fragmentShaderInterlockFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT };
+            VkPhysicalDeviceRayTracingMotionBlurFeaturesNV                  rayTracingMotionBlurFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV };
+            VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM   rasterizationOrderAttachmentAccessFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_ARM };
+            VkPhysicalDeviceShaderAtomicFloatFeaturesEXT                    shaderAtomicFloatFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT };
+            VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT                   shaderAtomicFloat2Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT };
+            VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT               shaderImageAtomicInt64Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT };
+            VkPhysicalDeviceIndexTypeUint8FeaturesEXT                       indexTypeUint8Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT };
+            VkPhysicalDeviceShaderClockFeaturesKHR                          shaderClockFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR };
+            VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR     subgroupUniformControlFlowFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR };
+            VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR        workgroupMemoryExplicitLayout = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR };
+            VkPhysicalDeviceComputeShaderDerivativesFeaturesNV              computeShaderDerivativesFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV };
+            VkPhysicalDeviceCoverageReductionModeFeaturesNV                 coverageReductionModeFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV };
+
+            VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV               deviceGeneratedCommandsFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV };
+            VkPhysicalDeviceMeshShaderFeaturesNV                            meshShaderFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV };
+            VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV            representativeFragmentTestFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV };
+            VkPhysicalDeviceColorWriteEnableFeaturesEXT                     colorWriteEnableFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT };
+            VkPhysicalDeviceConditionalRenderingFeaturesEXT                 conditionalRenderingFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT };
+            VkPhysicalDeviceDeviceMemoryReportFeaturesEXT                   deviceMemoryReportFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT };
+            VkPhysicalDeviceFragmentDensityMapFeaturesEXT                   fragmentDensityMapFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT };
+            VkPhysicalDeviceFragmentDensityMap2FeaturesEXT                  fragmentDensityMap2Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT };
+            VkPhysicalDeviceLineRasterizationFeaturesEXT                    lineRasterizationFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT };
+            VkPhysicalDeviceMemoryPriorityFeaturesEXT                       memoryPriorityFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT };
+            VkPhysicalDeviceRobustness2FeaturesEXT                          robustness2Features = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT };
+            VkPhysicalDevicePerformanceQueryFeaturesKHR                     performanceQueryFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR };
+            VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR         pipelineExecutablePropertiesFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR };
+            VkPhysicalDeviceCoherentMemoryFeaturesAMD                       coherentMemoryFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD };
+            VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL            intelShaderIntegerFunctions2 = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL };
+            VkPhysicalDeviceShaderImageFootprintFeaturesNV                  shaderImageFootprintFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV };
+            VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT                 texelBufferAlignmentFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT };
+            VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR                  globalPriorityFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR };
+            VkPhysicalDeviceASTCDecodeFeaturesEXT                           astcDecodeFeaturesEXT = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT };
+            VkPhysicalDeviceShaderSMBuiltinsFeaturesNV                      shaderSMBuiltinsFeatures = { VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV };
+            //! This is only written for convenience to avoid getting validation errors otherwise vulkan will just skip any strutctures it doesn't recognize
+            if (instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0))
+            {
+                addToPNextChain(&vulkan12Features);
+                addToPNextChain(&descriptorIndexingFeaturesEXT);
+                addToPNextChain(&shaderSubgroupExtendedTypesFeaturesKHR);
+                addToPNextChain(&hostQueryResetFeatures);
+                addToPNextChain(&scalarBlockLayoutFeatures);
+                addToPNextChain(&vulkanMemoryModelFeatures);
+                addToPNextChain(&separateDepthStencilLayoutsFeatures);
+                addToPNextChain(&uniformBufferStandardLayoutFeatures);
+                addToPNextChain(&_8BitStorageFeaturesKHR);
+                addToPNextChain(&shaderAtomicInt64FeaturesKHR);
+                addToPNextChain(&shaderFloat16Int8Features);
+            }
+            else
+            {
+                if (isExtensionSupported(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME))
+                    addToPNextChain(&descriptorIndexingFeaturesEXT);
+                if (isExtensionSupported(VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME))
+                    addToPNextChain(&shaderSubgroupExtendedTypesFeaturesKHR);
+                if (isExtensionSupported(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME))
+                    addToPNextChain(&hostQueryResetFeatures);
+                if (isExtensionSupported(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME))
+                    addToPNextChain(&scalarBlockLayoutFeatures);
+                if (isExtensionSupported(VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME))
+                    addToPNextChain(&vulkanMemoryModelFeatures);
+                if (isExtensionSupported(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME))
+                    addToPNextChain(&separateDepthStencilLayoutsFeatures);
+                if (isExtensionSupported(VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME))
+                    addToPNextChain(&uniformBufferStandardLayoutFeatures);
+                if (isExtensionSupported(VK_KHR_8BIT_STORAGE_EXTENSION_NAME))
+                    addToPNextChain(&_8BitStorageFeaturesKHR);
+                if (isExtensionSupported(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME))
+                    addToPNextChain(&shaderAtomicInt64FeaturesKHR);
+                if (isExtensionSupported(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME))
+                    addToPNextChain(&shaderFloat16Int8Features);
+            }
+            if (instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0))
+            {
+                addToPNextChain(&vulkan13Features);
+                addToPNextChain(&subgroupSizeControlFeatures);
+                addToPNextChain(&shaderTerminateInvocationFeatures);
+                addToPNextChain(&shaderIntegerDotProductFeatures);
+                addToPNextChain(&bufferDeviceAddressFeatures);
+                addToPNextChain(&imageRobustnessFeatures);
+                addToPNextChain(&pipelineCreationCacheControlFeatures);
+                addToPNextChain(&inlineUniformBlockFeatures);
+                addToPNextChain(&shaderDemoteToHelperInvocationFeaturesEXT);
+                addToPNextChain(&maintenance4Features);
+            }
+            else
+            {
+                if (isExtensionSupported(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME))
+                    addToPNextChain(&subgroupSizeControlFeatures);
+                if (isExtensionSupported(VK_KHR_SHADER_TERMINATE_INVOCATION_EXTENSION_NAME))
+                    addToPNextChain(&shaderTerminateInvocationFeatures);
+                if (isExtensionSupported(VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME))
+                    addToPNextChain(&shaderIntegerDotProductFeatures);
+                if (isExtensionSupported(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME))
+                    addToPNextChain(&bufferDeviceAddressFeatures);
+                if (isExtensionSupported(VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME))
+                    addToPNextChain(&imageRobustnessFeatures);
+                if (isExtensionSupported(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME))
+                    addToPNextChain(&pipelineCreationCacheControlFeatures);
+                if (isExtensionSupported(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME))
+                    addToPNextChain(&inlineUniformBlockFeatures);
+                if (isExtensionSupported(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME))
+                    addToPNextChain(&shaderDemoteToHelperInvocationFeaturesEXT);
+                if (isExtensionSupported(VK_KHR_MAINTENANCE_4_EXTENSION_NAME))
+                    addToPNextChain(&maintenance4Features);
+            }
+            if (isExtensionSupported(VK_NV_COOPERATIVE_MATRIX_EXTENSION_NAME))
+                addToPNextChain(&cooperativeMatrixFeatures);
+            if (isExtensionSupported(VK_KHR_RAY_QUERY_EXTENSION_NAME))
+                addToPNextChain(&rayQueryFeatures);
+            if (isExtensionSupported(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME))
+                addToPNextChain(&accelerationFeatures);
+            if (isExtensionSupported(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME))
+                addToPNextChain(&rayTracingPipelineFeatures);
+            if (isExtensionSupported(VK_EXT_FRAGMENT_SHADER_INTERLOCK_EXTENSION_NAME))
+                addToPNextChain(&fragmentShaderInterlockFeatures);
+            if (isExtensionSupported(VK_NV_RAY_TRACING_MOTION_BLUR_EXTENSION_NAME))
+                addToPNextChain(&rayTracingMotionBlurFeatures);
+            if (isExtensionSupported(VK_ARM_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_EXTENSION_NAME))
+                addToPNextChain(&rasterizationOrderAttachmentAccessFeatures);
+            if (isExtensionSupported(VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME))
+                addToPNextChain(&shaderAtomicFloatFeatures);
+            if (isExtensionSupported(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME))
+                addToPNextChain(&shaderAtomicFloat2Features);
+            if (isExtensionSupported(VK_EXT_SHADER_IMAGE_ATOMIC_INT64_EXTENSION_NAME))
+                addToPNextChain(&shaderImageAtomicInt64Features);
+            if (isExtensionSupported(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME))
+                addToPNextChain(&indexTypeUint8Features);
+            if (isExtensionSupported(VK_KHR_SHADER_CLOCK_EXTENSION_NAME))
+                addToPNextChain(&shaderClockFeatures);
+            if (isExtensionSupported(VK_KHR_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_EXTENSION_NAME))
+                addToPNextChain(&subgroupUniformControlFlowFeatures);
+            if (isExtensionSupported(VK_KHR_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_EXTENSION_NAME))
+                addToPNextChain(&workgroupMemoryExplicitLayout);
+            if (isExtensionSupported(VK_NV_COMPUTE_SHADER_DERIVATIVES_EXTENSION_NAME))
+                addToPNextChain(&computeShaderDerivativesFeatures);
+            if (isExtensionSupported(VK_NV_COVERAGE_REDUCTION_MODE_EXTENSION_NAME))
+                addToPNextChain(&coverageReductionModeFeatures);
+            if (isExtensionSupported(VK_NV_DEVICE_GENERATED_COMMANDS_EXTENSION_NAME))
+                addToPNextChain(&deviceGeneratedCommandsFeatures);
+            if (isExtensionSupported(VK_NV_MESH_SHADER_EXTENSION_NAME))
+                addToPNextChain(&meshShaderFeatures);
+            if (isExtensionSupported(VK_NV_REPRESENTATIVE_FRAGMENT_TEST_EXTENSION_NAME))
+                addToPNextChain(&representativeFragmentTestFeatures);
+            if (isExtensionSupported(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME))
+                addToPNextChain(&colorWriteEnableFeatures);
+            if (isExtensionSupported(VK_EXT_CONDITIONAL_RENDERING_EXTENSION_NAME))
+                addToPNextChain(&conditionalRenderingFeatures);
+            if (isExtensionSupported(VK_EXT_DEVICE_MEMORY_REPORT_EXTENSION_NAME))
+                addToPNextChain(&deviceMemoryReportFeatures);
+            if (isExtensionSupported(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME))
+                addToPNextChain(&fragmentDensityMapFeatures);
+            if (isExtensionSupported(VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME))
+                addToPNextChain(&fragmentDensityMap2Features);
+            if (isExtensionSupported(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME))
+                addToPNextChain(&lineRasterizationFeatures);
+            if (isExtensionSupported(VK_EXT_MEMORY_PRIORITY_EXTENSION_NAME))
+                addToPNextChain(&memoryPriorityFeatures);
+            if (isExtensionSupported(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME))
+                addToPNextChain(&robustness2Features);
+            if (isExtensionSupported(VK_KHR_PERFORMANCE_QUERY_EXTENSION_NAME))
+                addToPNextChain(&performanceQueryFeatures);
+            if (isExtensionSupported(VK_KHR_PIPELINE_EXECUTABLE_PROPERTIES_EXTENSION_NAME))
+                addToPNextChain(&pipelineExecutablePropertiesFeatures);
+            if (isExtensionSupported(VK_AMD_DEVICE_COHERENT_MEMORY_EXTENSION_NAME))
+                addToPNextChain(&coherentMemoryFeatures);
+            if (isExtensionSupported(VK_INTEL_SHADER_INTEGER_FUNCTIONS_2_EXTENSION_NAME))
+                addToPNextChain(&intelShaderIntegerFunctions2);
+            if (isExtensionSupported(VK_NV_SHADER_IMAGE_FOOTPRINT_EXTENSION_NAME))
+                addToPNextChain(&shaderImageFootprintFeatures);
+            if (isExtensionSupported(VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME))
+                addToPNextChain(&texelBufferAlignmentFeatures);
+            if (isExtensionSupported(VK_KHR_GLOBAL_PRIORITY_EXTENSION_NAME))
+                addToPNextChain(&globalPriorityFeatures);
+            if (isExtensionSupported(VK_EXT_ASTC_DECODE_MODE_EXTENSION_NAME))
+                addToPNextChain(&astcDecodeFeaturesEXT);
+            if (isExtensionSupported(VK_NV_SHADER_SM_BUILTINS_EXTENSION_NAME))
+                addToPNextChain(&shaderSMBuiltinsFeatures);
+            // call
+            finalizePNextChain();
+            vkGetPhysicalDeviceFeatures2(m_vkPhysicalDevice,&deviceFeatures);
 
             /* Vulkan 1.0 Core  */
+            const auto& features = deviceFeatures.features;
             m_features.robustBufferAccess = features.robustBufferAccess;
             m_features.fullDrawIndexUint32 = features.fullDrawIndexUint32;
             m_features.imageCubeArray = features.imageCubeArray;
@@ -674,13 +887,12 @@ public:
             m_features.shaderDrawParameters = vulkan11Features.shaderDrawParameters;
             
             /* Vulkan 1.2 Core  */
-            
-            if (instanceApiVersion >= VK_MAKE_API_VERSION(0, 1, 2, 0))
+            if (instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0))
             {
                 m_features.subgroupBroadcastDynamicId = vulkan12Features.subgroupBroadcastDynamicId;
             }
 
-            if (isExtensionSupported(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME))
+            if (instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME))
             {
                  m_features.descriptorIndexing = true;
                  m_features.shaderInputAttachmentArrayDynamicIndexing = descriptorIndexingFeaturesEXT.shaderInputAttachmentArrayDynamicIndexing;
@@ -709,18 +921,103 @@ public:
             m_features.drawIndirectCount = isExtensionSupported(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
             m_features.samplerFilterMinmax = isExtensionSupported(VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME);
             
-            if(isExtensionSupported(VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME))
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_KHR_SHADER_SUBGROUP_EXTENDED_TYPES_EXTENSION_NAME))
             {
                 m_features.shaderSubgroupExtendedTypes = shaderSubgroupExtendedTypesFeaturesKHR.shaderSubgroupExtendedTypes;
+            }
+            
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME))
+            {
+                m_features.hostQueryReset = hostQueryResetFeatures.hostQueryReset;
+            }
+            
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME))
+            {
+                m_features.scalarBlockLayout = scalarBlockLayoutFeatures.scalarBlockLayout;
+            }
+            
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME))
+            {
+                m_features.vulkanMemoryModel = vulkanMemoryModelFeatures.vulkanMemoryModel;
+                m_features.vulkanMemoryModelDeviceScope = vulkanMemoryModelFeatures.vulkanMemoryModelDeviceScope;
+                m_features.vulkanMemoryModelAvailabilityVisibilityChains = vulkanMemoryModelFeatures.vulkanMemoryModelAvailabilityVisibilityChains;
+            }
+            
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME))
+            {
+                m_features.separateDepthStencilLayouts = separateDepthStencilLayoutsFeatures.separateDepthStencilLayouts;
+            }
+            
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME))
+            {
+                m_features.uniformBufferStandardLayout = uniformBufferStandardLayoutFeatures.uniformBufferStandardLayout;
+            }
+            
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_KHR_8BIT_STORAGE_EXTENSION_NAME))
+            {
+                m_properties.limits.storageBuffer8BitAccess = _8BitStorageFeaturesKHR.storageBuffer8BitAccess;
+                m_properties.limits.uniformAndStorageBuffer8BitAccess = _8BitStorageFeaturesKHR.uniformAndStorageBuffer8BitAccess;
+                m_properties.limits.storagePushConstant8 = _8BitStorageFeaturesKHR.storagePushConstant8;
+            }
+            
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME))
+            {
+                m_properties.limits.shaderBufferInt64Atomics = shaderAtomicInt64FeaturesKHR.shaderBufferInt64Atomics;
+                m_properties.limits.shaderSharedInt64Atomics = shaderAtomicInt64FeaturesKHR.shaderSharedInt64Atomics;
+            }
+            
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,2,0)||isExtensionSupported(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME))
+            {
+                m_properties.limits.shaderFloat16 = shaderFloat16Int8Features.shaderFloat16;
+                m_properties.limits.shaderInt8 = shaderFloat16Int8Features.shaderInt8;
+            }
+
+            /* Vulkan 1.3 Core  */
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME))
+            {
+                m_features.subgroupSizeControl  = subgroupSizeControlFeatures.subgroupSizeControl;
+                m_features.computeFullSubgroups = subgroupSizeControlFeatures.computeFullSubgroups;
+            }
+
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_KHR_SHADER_TERMINATE_INVOCATION_EXTENSION_NAME))
+            {
+                m_features.shaderTerminateInvocation = shaderTerminateInvocationFeatures.shaderTerminateInvocation;
+            }
+
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME))
+            {
+                m_features.shaderIntegerDotProduct = shaderIntegerDotProductFeatures.shaderIntegerDotProduct;
+                // [TODO] there's a bunch of fields! https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR.html
+                    // RESPONSE FROM ERFAN: That's not features, that's properties
+            }
+
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME))
+            {
+                m_features.bufferDeviceAddress = bufferDeviceAddressFeatures.bufferDeviceAddress;
+                m_features.bufferDeviceAddressMultiDevice = bufferDeviceAddressFeatures.bufferDeviceAddressMultiDevice;
+            }
+
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME))
+            {
+                m_features.robustImageAccess = imageRobustnessFeatures.robustImageAccess;
+            }
+
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME))
+            {
+                m_features.pipelineCreationCacheControl = pipelineCreationCacheControlFeatures.pipelineCreationCacheControl;
+            }
+
+            if(instanceApiVersion>=VK_MAKE_API_VERSION(0,1,3,0)||isExtensionSupported(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME))
+            {
+                m_features.inlineUniformBlock = inlineUniformBlockFeatures.inlineUniformBlock;
+                m_features.descriptorBindingInlineUniformBlockUpdateAfterBind = inlineUniformBlockFeatures.descriptorBindingInlineUniformBlockUpdateAfterBind;
             }
 
             m_features.shaderDemoteToHelperInvocation = isExtensionSupported(VK_EXT_SHADER_DEMOTE_TO_HELPER_INVOCATION_EXTENSION_NAME);
 
-            /* Vulkan 1.3 Core  */
-            if(isExtensionSupported(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME))
+            if (isExtensionSupported(VK_KHR_MAINTENANCE_4_EXTENSION_NAME))
             {
-                m_features.subgroupSizeControl  = subgroupSizeControlFeatures.subgroupSizeControl;
-                m_features.computeFullSubgroups = subgroupSizeControlFeatures.computeFullSubgroups;
+                m_properties.limits.workgroupSizeFromSpecConstant = maintenance4Features.maintenance4;
             }
 
             /* Vulkan Extensions */
@@ -760,58 +1057,11 @@ public:
                 m_features.fragmentShaderShadingRateInterlock = fragmentShaderInterlockFeatures.fragmentShaderShadingRateInterlock;
             }
 
-            /* BufferDeviceAddressFeaturesKHR */
-            if (isExtensionSupported(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME))
-            {
-                m_features.bufferDeviceAddress = bufferDeviceAddressFeatures.bufferDeviceAddress;
-                m_features.bufferDeviceAddressMultiDevice = bufferDeviceAddressFeatures.bufferDeviceAddressMultiDevice;
-            }
-
             /* RayTracingMotionBlurFeaturesNV */
             if (isExtensionSupported(VK_NV_RAY_TRACING_MOTION_BLUR_EXTENSION_NAME))
             {
                 m_features.rayTracingMotionBlur = rayTracingMotionBlurFeatures.rayTracingMotionBlur;
                 m_features.rayTracingMotionBlurPipelineTraceRaysIndirect = rayTracingMotionBlurFeatures.rayTracingMotionBlurPipelineTraceRaysIndirect;
-            }
-
-            /* VkPhysicalDeviceUniformBufferStandardLayoutFeatures */
-            if (isExtensionSupported(VK_KHR_UNIFORM_BUFFER_STANDARD_LAYOUT_EXTENSION_NAME))
-            {
-                m_features.uniformBufferStandardLayout = uniformBufferStandardLayoutFeatures.uniformBufferStandardLayout;
-            }
-
-            /* VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures */
-            if (isExtensionSupported(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME))
-            {
-                m_features.separateDepthStencilLayouts = separateDepthStencilLayoutsFeatures.separateDepthStencilLayouts;
-            }
-
-            /* VkPhysicalDeviceVulkanMemoryModelFeatures */
-            if (isExtensionSupported(VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME))
-            {
-                m_features.vulkanMemoryModel = vulkanMemoryModelFeatures.vulkanMemoryModel;
-                m_features.vulkanMemoryModelDeviceScope = vulkanMemoryModelFeatures.vulkanMemoryModelDeviceScope;
-                m_features.vulkanMemoryModelAvailabilityVisibilityChains = vulkanMemoryModelFeatures.vulkanMemoryModelAvailabilityVisibilityChains;
-            }
-
-            /* VkPhysicalDeviceScalarBlockLayoutFeatures */
-            if (isExtensionSupported(VK_EXT_SCALAR_BLOCK_LAYOUT_EXTENSION_NAME))
-            {
-                m_features.scalarBlockLayout = scalarBlockLayoutFeatures.scalarBlockLayout;
-            }
-
-            /* VkPhysicalDeviceShaderTerminateInvocationFeatures */
-            if (isExtensionSupported(VK_KHR_SHADER_TERMINATE_INVOCATION_EXTENSION_NAME))
-            {
-                m_features.shaderTerminateInvocation = shaderTerminateInvocationFeatures.shaderTerminateInvocation;
-            }
-
-            /* VkPhysicalDeviceShaderTerminateInvocationFeatures */
-            if (isExtensionSupported(VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME))
-            {
-                m_features.shaderIntegerDotProduct = shaderIntegerDotProductFeatures.shaderIntegerDotProduct;
-                // [TODO] there's a bunch of fields! https://www.khronos.org/registry/vulkan/specs/1.3-extensions/man/html/VkPhysicalDeviceShaderIntegerDotProductPropertiesKHR.html
-                    // RESPONSE FROM ERFAN: That's not features, that's properties
             }
 
             /* VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesARM */
@@ -957,24 +1207,6 @@ public:
                 m_features.bufferMarkerAMD = true;
             }
 
-            /* VkPhysicalDeviceHostQueryResetFeatures */
-            if (isExtensionSupported(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME))
-            {
-                m_features.hostQueryReset = hostQueryResetFeatures.hostQueryReset;
-            }
-
-            /* VkPhysicalDeviceImageRobustnessFeatures */
-            if (isExtensionSupported(VK_EXT_IMAGE_ROBUSTNESS_EXTENSION_NAME))
-            {
-                m_features.robustImageAccess = imageRobustnessFeatures.robustImageAccess;
-            }
-
-            /* VkPhysicalDevicePipelineCreationCacheControlFeatures */
-            if (isExtensionSupported(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME))
-            {
-                m_features.pipelineCreationCacheControl = pipelineCreationCacheControlFeatures.pipelineCreationCacheControl;
-            }
-
             /* VkPhysicalDeviceColorWriteEnableFeaturesEXT */
             if (isExtensionSupported(VK_EXT_COLOR_WRITE_ENABLE_EXTENSION_NAME))
             {
@@ -1006,13 +1238,6 @@ public:
             if (isExtensionSupported(VK_EXT_FRAGMENT_DENSITY_MAP_2_EXTENSION_NAME))
             {
                 m_features.fragmentDensityMapDeferred = fragmentDensityMap2Features.fragmentDensityMapDeferred;
-            }
-
-            /* VkPhysicalDeviceInlineUniformBlockFeatures */
-            if (isExtensionSupported(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME))
-            {
-                m_features.inlineUniformBlock = inlineUniformBlockFeatures.inlineUniformBlock;
-                m_features.descriptorBindingInlineUniformBlockUpdateAfterBind = inlineUniformBlockFeatures.descriptorBindingInlineUniformBlockUpdateAfterBind;
             }
 
             /* VkPhysicalDeviceLineRasterizationFeaturesEXT */
@@ -1081,25 +1306,6 @@ public:
             m_properties.limits.uniformAndStorageBuffer16BitAccess = vulkan11Features.uniformAndStorageBuffer16BitAccess;
             m_properties.limits.storagePushConstant16 = vulkan11Features.storagePushConstant16;
             m_properties.limits.storageInputOutput16 = vulkan11Features.storageInputOutput16;
-
-            if (isExtensionSupported(VK_KHR_8BIT_STORAGE_EXTENSION_NAME))
-            {
-                m_properties.limits.storageBuffer8BitAccess = _8BitStorageFeaturesKHR.storageBuffer8BitAccess;
-                m_properties.limits.uniformAndStorageBuffer8BitAccess = _8BitStorageFeaturesKHR.uniformAndStorageBuffer8BitAccess;
-                m_properties.limits.storagePushConstant8 = _8BitStorageFeaturesKHR.storagePushConstant8;
-            }
-            
-            if (isExtensionSupported(VK_KHR_SHADER_ATOMIC_INT64_EXTENSION_NAME))
-            {
-                m_properties.limits.shaderBufferInt64Atomics = shaderAtomicInt64FeaturesKHR.shaderBufferInt64Atomics;
-                m_properties.limits.shaderSharedInt64Atomics = shaderAtomicInt64FeaturesKHR.shaderSharedInt64Atomics;
-            }
-
-            if (isExtensionSupported(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME))
-            {
-                m_properties.limits.shaderFloat16 = shaderFloat16Int8Features.shaderFloat16;
-                m_properties.limits.shaderInt8 = shaderFloat16Int8Features.shaderInt8;
-            }
             
             if (isExtensionSupported(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME))
             {
@@ -1135,11 +1341,6 @@ public:
             if(isExtensionSupported(VK_NV_SHADER_SM_BUILTINS_EXTENSION_NAME))
             {
                 m_properties.limits.shaderSMBuiltins = shaderSMBuiltinsFeatures.shaderSMBuiltins;
-            }
-
-            if (isExtensionSupported(VK_KHR_MAINTENANCE_4_EXTENSION_NAME))
-            {
-                m_properties.limits.workgroupSizeFromSpecConstant = maintenance4Features.maintenance4;
             }
 
             m_properties.limits.shaderSubgroupPartitioned = isExtensionSupported(VK_NV_SHADER_SUBGROUP_PARTITIONED_EXTENSION_NAME);

--- a/src/nbl/video/CVulkanPhysicalDevice.h
+++ b/src/nbl/video/CVulkanPhysicalDevice.h
@@ -1415,6 +1415,33 @@ public:
         for(uint32_t i = 0; i < asset::EF_COUNT; ++i)
         {
             const asset::E_FORMAT format = static_cast<asset::E_FORMAT>(i);
+            bool skip = false;
+            switch (format)
+            {
+                case asset::EF_B4G4R4A4_UNORM_PACK16:
+                case asset::EF_R4G4B4A4_UNORM_PACK16:
+                    if (instanceApiVersion<VK_MAKE_API_VERSION(0,1,3,0) && !isExtensionSupported(VK_EXT_4444_FORMATS_EXTENSION_NAME))
+                        skip = true;
+                    break;
+                // TODO: ASTC HDR stuff
+                //case asset::EF_ASTC__SFLOAT
+                    //if (instanceApiVersion<VK_MAKE_API_VERSION(0,1,3,0) && !isExtensionSupported(VK_EXT_TEXTURE_COMPRESSION_ASTC_HDR_EXTENSION_NAME))
+                    //    skip = true;
+                    //break;
+                case asset::EF_PVRTC1_2BPP_UNORM_BLOCK_IMG:
+                case asset::EF_PVRTC1_4BPP_UNORM_BLOCK_IMG:
+                case asset::EF_PVRTC2_2BPP_UNORM_BLOCK_IMG:
+                case asset::EF_PVRTC2_4BPP_UNORM_BLOCK_IMG:
+                case asset::EF_PVRTC1_2BPP_SRGB_BLOCK_IMG:
+                case asset::EF_PVRTC1_4BPP_SRGB_BLOCK_IMG:
+                case asset::EF_PVRTC2_2BPP_SRGB_BLOCK_IMG:
+                case asset::EF_PVRTC2_4BPP_SRGB_BLOCK_IMG:
+                    if (!isExtensionSupported(VK_IMG_FORMAT_PVRTC_EXTENSION_NAME))
+                        skip = true;
+                    break;
+            }
+            if (skip)
+                continue;
 
             VkFormatProperties vk_formatProps;
             vkGetPhysicalDeviceFormatProperties(m_vkPhysicalDevice, getVkFormatFromFormat(format), &vk_formatProps);
@@ -1433,7 +1460,7 @@ public:
             m_linearTilingUsages[format].blitDst = (linearTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT) ? 1 : 0;
             m_linearTilingUsages[format].transferSrc = (linearTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) ? 1 : 0;
             m_linearTilingUsages[format].transferDst = (linearTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) ? 1 : 0;
-            // m_linearTilingUsages[format].log2MaxSmples = ; // Todo(achal)
+            // m_linearTilingUsages[format].log2MaxSmples = ; // Todo(Erfan)
             
             m_optimalTilingUsages[format] = {};
             m_optimalTilingUsages[format].sampledImage = optimalTilingFeatures & (VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) ? 1 : 0;
@@ -1445,7 +1472,7 @@ public:
             m_optimalTilingUsages[format].blitDst = optimalTilingFeatures & VK_FORMAT_FEATURE_BLIT_DST_BIT ? 1 : 0;
             m_optimalTilingUsages[format].transferSrc = optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT ? 1 : 0;
             m_optimalTilingUsages[format].transferDst = optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT ? 1 : 0;
-            // m_optimalTilingUsages[format].log2MaxSmples = ; // Todo(achal)
+            // m_optimalTilingUsages[format].log2MaxSmples = ; // Todo(Erfan)
             
             m_bufferUsages[format] = {};
             m_bufferUsages[format].vertexAttribute = (bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) ? 1 : 0;

--- a/src/nbl/video/IGPUCommandBuffer.cpp
+++ b/src/nbl/video/IGPUCommandBuffer.cpp
@@ -913,7 +913,7 @@ bool IGPUCommandBuffer::blitImage(const image_t* srcImage, asset::IImage::E_LAYO
 
     for (uint32_t i = 0u; i < regionCount; ++i)
     {
-        if (pRegions[i].dstSubresource.aspectMask != pRegions[i].srcSubresource.aspectMask)
+        if (pRegions[i].dstSubresource.aspectMask.value != pRegions[i].srcSubresource.aspectMask.value)
             return false;
         if (pRegions[i].dstSubresource.layerCount != pRegions[i].srcSubresource.layerCount)
             return false;


### PR DESCRIPTION
## Description

Fixes:
- querying for device properties and limits for extensions that are not supported (dynamic pNext chain construction)
- querying format usages for formats which are not supported (no extension or vulkan instance version)
- not generating mip-maps for images that already have defined mip pyramids (like KTX/DDS)
- only make the mip-pyramid full if there was no mip-pyramid to start with in the first place
- fix #411 
- upstream a bunch of fixes from `ditt` branch
- minor issues with compilation of certain examples

## Testing 

Just running examples, nothing complex like comparing device props and limit structs before and after implementing changes.

## TODO list:

Actually fix #472 
