### PR TITLE
Make SHARED builtin-resources builds work

### DIFF
--- a/include/nbl/system/CFileArchive.h
+++ b/include/nbl/system/CFileArchive.h
@@ -68,7 +68,7 @@ class CInnerArchiveFile : public CFileView<T>
 
 
 //!
-class CFileArchive : public IFileArchive
+class NBL_API2 CFileArchive : public IFileArchive
 {
 		static inline constexpr size_t SIZEOF_INNER_ARCHIVE_FILE = std::max(sizeof(CInnerArchiveFile<CPlainHeapAllocator>), sizeof(CInnerArchiveFile<VirtualMemoryAllocator>));
 		static inline constexpr size_t ALIGNOF_INNER_ARCHIVE_FILE = std::max(alignof(CInnerArchiveFile<CPlainHeapAllocator>), alignof(CInnerArchiveFile<VirtualMemoryAllocator>));

--- a/include/nbl/system/atomic_state.h
+++ b/include/nbl/system/atomic_state.h
@@ -2,6 +2,7 @@
 #define _NBL_SYSTEM_ATOMIC_STATE_H_INCLUDED_
 
 #include <atomic>
+#include "assert.h"
 
 namespace nbl::system
 {

--- a/src/nbl/builtin/CMakeLists.txt
+++ b/src/nbl/builtin/CMakeLists.txt
@@ -240,6 +240,6 @@ LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "glsl/blit/normalization/shared_nor
 LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "hlsl/shapes/line.hlsl")
 
 macro(NBL_ADD_BUILTIN_RESOURCES _TARGET_) # internal & Nabla only, must be added with the macro to properly propagate scope
-	ADD_CUSTOM_BUILTIN_RESOURCES("${_TARGET_}" NBL_RESOURCES_TO_EMBED "${NBL_ROOT_PATH}/include" "nbl/builtin" "nbl::builtin" "${NBL_ROOT_PATH_BINARY}/include" "${NBL_ROOT_PATH_BINARY}/src")
+	ADD_CUSTOM_BUILTIN_RESOURCES("${_TARGET_}" NBL_RESOURCES_TO_EMBED "${NBL_ROOT_PATH}/include" "nbl/builtin" "nbl::builtin" "${NBL_ROOT_PATH_BINARY}/include" "${NBL_ROOT_PATH_BINARY}/src" "STATIC" "INTERNAL")
 endmacro()
 

--- a/src/nbl/builtin/builtinHeaderGen.py
+++ b/src/nbl/builtin/builtinHeaderGen.py
@@ -29,11 +29,11 @@ else:
     outp.write("#ifndef _" + guardSuffix + "_BUILTINRESOURCEDATA_H_\n")
     outp.write("#define _" + guardSuffix + "_BUILTINRESOURCEDATA_H_\n")
   
-    outp.write("#ifdef _WIN32 // Visual Studio define\n")
+    outp.write("#ifdef __INTELLISENSE__\n")
     outp.write("#include <codeanalysis\warnings.h>\n")
     outp.write("#pragma warning( push )\n")
     outp.write("#pragma warning ( disable : ALL_CODE_ANALYSIS_WARNINGS )\n")
-    outp.write("#endif // _WIN32\n")
+    outp.write("#endif // __INTELLISENSE__\n")
 
     outp.write("#include <stdlib.h>\n")
     outp.write("#include <cstdint>\n")
@@ -85,9 +85,9 @@ else:
 
     outp.write("\n\t}\n")
     
-    outp.write("#ifdef _WIN32\n")
+    outp.write("#ifdef __INTELLISENSE__\n")
     outp.write("#pragma warning( pop )\n")
-    outp.write("#endif // _WIN32\n")
+    outp.write("#endif // __INTELLISENSE__\n")
     
     outp.write("#endif // _" + guardSuffix + "_BUILTINRESOURCEDATA_H_")
 

--- a/src/nbl/builtin/builtinHeaderGen.py
+++ b/src/nbl/builtin/builtinHeaderGen.py
@@ -28,6 +28,13 @@ else:
 
     outp.write("#ifndef _" + guardSuffix + "_BUILTINRESOURCEDATA_H_\n")
     outp.write("#define _" + guardSuffix + "_BUILTINRESOURCEDATA_H_\n")
+  
+    outp.write("#ifdef _WIN32 // Visual Studio define\n")
+    outp.write("#include <codeanalysis\warnings.h>\n")
+    outp.write("#pragma warning( push )\n")
+    outp.write("#pragma warning ( disable : ALL_CODE_ANALYSIS_WARNINGS )\n")
+    outp.write("#endif // _WIN32\n")
+
     outp.write("#include <stdlib.h>\n")
     outp.write("#include <cstdint>\n")
     outp.write("#include <string>\n")
@@ -76,7 +83,12 @@ else:
                 else:
                     outp.write('\n\t\ttemplate<> const std::pair<const uint8_t*, size_t> get_resource<NBL_CORE_UNIQUE_STRING_LITERAL_TYPE("%s")>();' % itemData[i].rstrip())
 
-    outp.write("\n\t}")
-    outp.write("\n#endif // _" + guardSuffix + "_BUILTINRESOURCEDATA_H_")
+    outp.write("\n\t}\n")
+    
+    outp.write("#ifdef _WIN32\n")
+    outp.write("#pragma warning( pop )\n")
+    outp.write("#endif // _WIN32\n")
+    
+    outp.write("#endif // _" + guardSuffix + "_BUILTINRESOURCEDATA_H_")
 
     outp.close()

--- a/src/nbl/builtin/template/CArchive.h.in
+++ b/src/nbl/builtin/template/CArchive.h.in
@@ -2,6 +2,7 @@
 #define _@_GUARD_SUFFIX_@_C_ARCHIVE_H_
 
 #include "nbl/system/CFileArchive.h"
+#include "nbl/core/def/smart_refctd_ptr.h"
 #include "@NBL_BS_HEADER_FILENAME@"
 
 namespace @_NAMESPACE_@
@@ -9,7 +10,7 @@ namespace @_NAMESPACE_@
 	constexpr std::string_view pathPrefix = "@_BUNDLE_ARCHIVE_ABSOLUTE_PATH_@";
 	constexpr bool hasPathPrefix(std::string_view str) { return str.find(pathPrefix) == 0ull; }
 
-	class @_NBL_BR_API_@ CArchive final : public nbl::system::CFileArchive
+	class @NBL_BR_API@ CArchive final : public nbl::system::CFileArchive
 	{
 		public:
 			CArchive(nbl::system::logger_opt_smart_ptr&& logger);

--- a/src/nbl/builtin/utils.cmake
+++ b/src/nbl/builtin/utils.cmake
@@ -159,6 +159,10 @@ function(ADD_CUSTOM_BUILTIN_RESOURCES _TARGET_NAME_ _BUNDLE_NAME_ _BUNDLE_SEARCH
 	if(TARGET Nabla)
 		get_target_property(_NABLA_INCLUDE_DIRECTORIES_ Nabla INCLUDE_DIRECTORIES)
 		
+		if(NBL_STATIC_BUILD AND _LIB_TYPE_ STREQUAL SHARED)
+			message(FATAL_ERROR "Nabla must be built as dynamic library in order to combine this tool with SHARED setup!")
+		endif()
+		
 		if(NOT _NBL_INTERNAL_BR_CREATION_)
 			target_link_libraries(${_TARGET_NAME_} Nabla) # be aware Nabla must be linked to the BRs
 		endif()

--- a/src/nbl/builtin/utils.cmake
+++ b/src/nbl/builtin/utils.cmake
@@ -55,6 +55,12 @@ function(ADD_CUSTOM_BUILTIN_RESOURCES _TARGET_NAME_ _BUNDLE_NAME_ _BUNDLE_SEARCH
 		set(_SHARED_ False)
 		unset(NBL_BR_API)
 	endif()
+	
+	if("${ARGV8}" STREQUAL "INTERNAL")
+		set(_NBL_INTERNAL_BR_CREATION_ ON)
+	else()
+		set(_NBL_INTERNAL_BR_CREATION_ OFF)
+	endif()
 
 	set(NBL_TEMPLATE_RESOURCES_ARCHIVE_HEADER "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/CArchive.h.in")
 	set(NBL_TEMPLATE_RESOURCES_ARCHIVE_SOURCE "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/template/CArchive.cpp.in")
@@ -152,6 +158,10 @@ function(ADD_CUSTOM_BUILTIN_RESOURCES _TARGET_NAME_ _BUNDLE_NAME_ _BUNDLE_SEARCH
 	
 	if(TARGET Nabla)
 		get_target_property(_NABLA_INCLUDE_DIRECTORIES_ Nabla INCLUDE_DIRECTORIES)
+		
+		if(NOT _NBL_INTERNAL_BR_CREATION_)
+			target_link_libraries(${_TARGET_NAME_} Nabla) # be aware Nabla must be linked to the BRs
+		endif()
 	endif()
 	
 	if(NOT DEFINED _NABLA_INCLUDE_DIRECTORIES_) # TODO, validate by populating generator expressions if any and checking whether a path to the BuildConfigOptions.h exists per config


### PR DESCRIPTION
Require Nabla to be linked into BRs libraries due to some codebase symbols, add SHARED builtin-resources test to examples 52. Apply some fixes and mute IntelliSense in builtin-resources headers