### PR TITLE
Mount directories fix

### DIFF
--- a/include/nbl/system/CFileArchive.h
+++ b/include/nbl/system/CFileArchive.h
@@ -108,8 +108,7 @@ class NBL_API2 CFileArchive : public IFileArchive
 		CFileArchive(path&& _defaultAbsolutePath, system::logger_opt_smart_ptr&& logger, std::shared_ptr<core::vector<SFileList::SEntry>> _items) :
 			IFileArchive(std::move(_defaultAbsolutePath),std::move(logger))
 		{
-			std::sort(_items->begin(), _items->end());
-			m_items.store(_items);
+			setItemList(_items);
 
 			const auto fileCount = _items->size();
 			m_filesBuffer = (std::byte*)_NBL_ALIGNED_MALLOC(fileCount*SIZEOF_INNER_ARCHIVE_FILE, ALIGNOF_INNER_ARCHIVE_FILE);

--- a/include/nbl/system/CMountDirectoryArchive.h
+++ b/include/nbl/system/CMountDirectoryArchive.h
@@ -33,18 +33,9 @@ public:
             return *file;
     }
 
-    SFileList listAssets(const path& asset_path) const override
-    {
-        populateItemList(asset_path);
-        return IFileArchive::listAssets(asset_path);
-    }
+ 
     SFileList listAssets() const override {
-        populateItemList(path());
-        return IFileArchive::listAssets();
-    }
-
-    void populateItemList(const path& p) const {
-        auto items = m_system->listItemsInDirectory(m_defaultAbsolutePath/p);
+        auto items = m_system->listItemsInDirectory(m_defaultAbsolutePath);
         auto new_entries = std::make_shared<core::vector<SFileList::SEntry>>();
         for (auto item : items)
         {
@@ -55,7 +46,13 @@ public:
                 new_entries->push_back(entry);
             }
         }
-        m_items.store({new_entries});
+        setItemList(new_entries);
+
+        return IFileArchive::listAssets();
+    }
+
+    void populateItemList(const path& p) const {
+       
     }
 };
 

--- a/include/nbl/system/IFileArchive.h
+++ b/include/nbl/system/IFileArchive.h
@@ -90,7 +90,7 @@ class NBL_API2 IFileArchive : public core::IReferenceCounted
 		}
 
 		// List all files and directories in a specific dir of the archive
-		SFileList listAssets(const path& pathRelativeToArchive) const;
+		SFileList listAssets(path pathRelativeToArchive) const;
 
 		//
 		virtual core::smart_refctd_ptr<IFile> getFile(const path& pathRelativeToArchive, const std::string_view& password) = 0;

--- a/include/nbl/system/IFileArchive.h
+++ b/include/nbl/system/IFileArchive.h
@@ -90,7 +90,7 @@ class NBL_API2 IFileArchive : public core::IReferenceCounted
 		}
 
 		// List all files and directories in a specific dir of the archive
-		virtual SFileList listAssets(const path& pathRelativeToArchive) const;
+		SFileList listAssets(const path& pathRelativeToArchive) const;
 
 		//
 		virtual core::smart_refctd_ptr<IFile> getFile(const path& pathRelativeToArchive, const std::string_view& password) = 0;
@@ -114,9 +114,17 @@ class NBL_API2 IFileArchive : public core::IReferenceCounted
 
 		path m_defaultAbsolutePath;
 		// files and directories
-		mutable std::atomic<SFileList::refctd_storage_t> m_items;
 		//
 		system::logger_opt_smart_ptr m_logger;
+
+		inline void setItemList(std::shared_ptr<core::vector<SFileList::SEntry>> _items) const {
+			
+			std::sort(_items->begin(), _items->end());
+			m_items.store(_items);
+		}
+
+	private:
+		mutable std::atomic<SFileList::refctd_storage_t> m_items;
 };
 
 

--- a/src/nbl/system/IFileArchive.cpp
+++ b/src/nbl/system/IFileArchive.cpp
@@ -13,7 +13,15 @@ IFileArchive::SFileList IFileArchive::listAssets(const path& pathRelativeToArchi
 			auto begin = trimmedList.m_data->begin();
 			auto end = trimmedList.m_data->end();
 			const SFileList::SEntry itemToFind = { pathRelativeToArchive };
-			trimmedList.m_range = { &(*std::lower_bound(begin,end,itemToFind)),&(*std::upper_bound(begin,end,itemToFind)) };
+			auto startswith = [](const SFileList::SEntry& lhs, const SFileList::SEntry& rhs) 
+			{
+					auto l = lhs.pathRelativeToArchive.wstring();
+					auto r = rhs.pathRelativeToArchive.wstring();
+					int len = std::min(l.length(), r.length());
+					return l.substr(0, len) < r.substr(0, len);
+			};
+
+			trimmedList.m_range = { &(*std::lower_bound(begin,end,itemToFind,startswith)),&(*std::upper_bound(begin,end,itemToFind,startswith)) };
 		}
 		return trimmedList;
 

--- a/src/nbl/system/IFileArchive.cpp
+++ b/src/nbl/system/IFileArchive.cpp
@@ -6,37 +6,44 @@ using namespace nbl;
 using namespace nbl::system;
 
 
-IFileArchive::SFileList IFileArchive::listAssets(const path& pathRelativeToArchive) const
+IFileArchive::SFileList IFileArchive::listAssets(path pathRelativeToArchive) const
 {
 		auto trimmedList = listAssets();
 		{
+			// remove trailing slash chars from pathRelativeToArchive
+			auto pathstr = pathRelativeToArchive.string();
+			while (pathstr.ends_with("/") || pathstr.ends_with("\\"))
+			{
+				pathstr= pathstr.substr(0, pathstr.length() - 1);
+			}
+			pathRelativeToArchive = pathstr;
+
 			auto begin = trimmedList.m_data->begin();
 			auto end = trimmedList.m_data->end();
-			const SFileList::SEntry itemToFind = { pathRelativeToArchive };
-			auto startswith = [](const SFileList::SEntry& lhs, const SFileList::SEntry& rhs) 
-			{
-					auto l = lhs.pathRelativeToArchive.wstring();
-					auto r = rhs.pathRelativeToArchive.wstring();
-					int len = std::min(l.length(), r.length());
-					return l.substr(0, len) < r.substr(0, len);
-			};
+			auto real_end = trimmedList.m_range.end();
 
-			trimmedList.m_range = { &(*std::lower_bound(begin,end,itemToFind,startswith)),&(*std::upper_bound(begin,end,itemToFind,startswith)) };
+			// finding paths with pathRelativeToArchive prefixes
+			// SEntry::operator> is equivalent to comparing strings lexicographically, in other words compares ascii codes of chars in paths, and shorter path is always lesser 
+			// std::lower_bound finds first element >= SEntry arg
+			// 
+			// we want to find all matches that meet this criteria (> is lexicographical string comparing)
+			// pathRelativeToArchive < match < pathRelativeToArchive+1
+			//
+			// lower bound
+			// by appending slash and char with code 1, we essentially make sure that all matches will be lexicographically greater, and start with pathRelativeToArchive/
+			auto lower = std::lower_bound(begin,end, SFileList::SEntry{pathRelativeToArchive/"\1"});
+			if (lower!=end)
+			{
+				// upper bound
+				// we cannot do std::upper_bound, because any value longer than pathRelativeToArchive is greater, thus the only matches between std::lower_bound and std::upper_bound would be ones exactly matching pathRelativeToArchive
+				// by appending char with code 1 and taking the lower bound, we can find the first element with prefix greater than pathRelativeToArchive, thus the upper bound
+				auto upper = std::lower_bound(lower,end,SFileList::SEntry{pathRelativeToArchive.string()+"\1"});
+				trimmedList.m_range = {&(*lower),upper!=end ? &(*upper):real_end};
+			}
+			else
+				trimmedList.m_range = {real_end,real_end};
 		}
 		return trimmedList;
-
-
-	/*
-	// future, cause lower/upper bound don't work like that
-	auto begin = std::lower_bound(m_items.begin(), m_items.end(),asset_path);
-	if (begin!=m_items.end())
-	{
-		auto end = std::upper_bound(begin,m_items.end(),asset_path);
-		if (begin==end)
-			return {&(*begin),&(*end)};
-	}
-	return {nullptr,nullptr};
-	*/
 }
 
 


### PR DESCRIPTION
## Description
In this PR `IFileArchive::listAssets(const path& pathRelativeToArchive)` method was changed to no longer be virtual, to take a parameter that is not const and its implementation was changed to return lexicographically in range matches.
Because the match range's bounds are not easy to imagine, i wrote a long comment explaining what is happening.

`IFileArchive::m_items` became private, and can be assigned via protected method

