### PR TITLE
E_DEBUG_LEVEL_INFO

### DIFF
--- a/include/nbl/asset/utils/CSPIRVIntrospector.h
+++ b/include/nbl/asset/utils/CSPIRVIntrospector.h
@@ -104,7 +104,7 @@ class NBL_API2 CSPIRVIntrospector : public core::Uncopyable
 		CSPIRVIntrospector() = default;
 
 		//! params.cpuShader.contentType should be ECT_SPIRV
-		//! the compiled SPIRV must be compiled with IShaderCompiler::SCompilerOptions::genDebugInfo with no `spirvOptimizer` used in order to include names in introspection data
+		//! the compiled SPIRV must be compiled with IShaderCompiler::SCompilerOptions::debugInfoFlags enabling EDIF_SOURCE_BIT implicitly or explicitly, with no `spirvOptimizer` used in order to include names in introspection data
 		core::smart_refctd_ptr<const CIntrospectionData> introspect(const SIntrospectionParams& params, bool insertToCache = true);
 
 		//

--- a/include/nbl/asset/utils/IShaderCompiler.h
+++ b/include/nbl/asset/utils/IShaderCompiler.h
@@ -119,13 +119,25 @@ class NBL_API2 IShaderCompiler : public core::IReferenceCounted
 			core::SRange<const char* const> extraDefines = {nullptr, nullptr};
 		};
 
+		// https://github.com/microsoft/DirectXShaderCompiler/blob/main/docs/SPIR-V.rst#debugging
+		enum class E_DEBUG_INFO_FLAGS : uint8_t
+		{
+			EDIF_NONE       = 0x00,
+			EDIF_FILE_BIT   = 0x01,       //  for emitting full path of the main source file
+			EDIF_SOURCE_BIT = 0x02,       //  for emitting preprocessed source code (turns on EDIF_FILE_BIT implicitly)
+			EDIF_LINE_BIT   = 0x04,       //  for emitting line information (turns on EDIF_SOURCE_BIT implicitly)
+			EDIF_TOOL_BIT   = 0x08,       //  for emitting Compiler Git commit hash and command-line options
+			EDIF_NON_SEMANTIC_BIT = 0x10, // NonSemantic.Shader.DebugInfo.100 extended instructions, this option overrules the options above
+		};
+		static constexpr core::bitflag<E_DEBUG_INFO_FLAGS> DefaultDebugInfoFlags = core::bitflag<E_DEBUG_INFO_FLAGS>(E_DEBUG_INFO_FLAGS::EDIF_SOURCE_BIT) | E_DEBUG_INFO_FLAGS::EDIF_TOOL_BIT;
+
 		/*
 			@stage shaderStage
 			@targetSpirvVersion spirv version
 			@entryPoint entryPoint
 			@outAssembly Optional parameter; if not nullptr, SPIR-V assembly is saved in there.
 			@spirvOptimizer Optional parameter;
-			@genDebugInfo Requests compiler to generate debug info (most importantly objects' names).
+			@debugInfoFlags See E_DEBUG_INFO_FLAGS enum for more information on possible values
 				Anything non-vulkan, basically you can't recover the names of original variables with CSPIRVIntrospector without debug info
 				By variables we mean names of PC/SSBO/UBO blocks, as they're essentially instantiations of structs with custom packing.
 			@preprocessorOptions
@@ -140,7 +152,7 @@ class NBL_API2 IShaderCompiler : public core::IReferenceCounted
 			IShader::E_SHADER_STAGE stage = IShader::E_SHADER_STAGE::ESS_UNKNOWN;
 			E_SPIRV_VERSION targetSpirvVersion = E_SPIRV_VERSION::ESV_1_6;
 			const ISPIRVOptimizer* spirvOptimizer = nullptr;
-			bool genDebugInfo = true;
+			core::bitflag<E_DEBUG_INFO_FLAGS> debugInfoFlags = DefaultDebugInfoFlags;
 			SPreprocessorOptions preprocessorOptions = {};
 
 			void setCommonData(const SCompilerOptions& opt)
@@ -150,6 +162,7 @@ class NBL_API2 IShaderCompiler : public core::IReferenceCounted
 
 			virtual IShader::E_CONTENT_TYPE getCodeContentType() const { return IShader::E_CONTENT_TYPE::ECT_UNKNOWN; };
 		};
+
 
 		virtual core::smart_refctd_ptr<ICPUShader> compileToSPIRV(const char* code, const SCompilerOptions& options) const = 0;
 
@@ -282,6 +295,8 @@ class NBL_API2 IShaderCompiler : public core::IReferenceCounted
 	private:
 		core::smart_refctd_ptr<CIncludeFinder> m_defaultIncludeFinder;
 };
+
+NBL_ENUM_ADD_BITWISE_OPERATORS(IShaderCompiler::E_DEBUG_INFO_FLAGS)
 
 }
 

--- a/include/nbl/core/util/bitflag.h
+++ b/include/nbl/core/util/bitflag.h
@@ -19,20 +19,20 @@ struct bitflag final
 
 	ENUM_TYPE value = static_cast<ENUM_TYPE>(0);
 
-	bitflag() = default;
-	bitflag(const ENUM_TYPE value) : value(value) {}
+	constexpr bitflag() = default;
+	constexpr bitflag(const ENUM_TYPE value) : value(value) {}
 	template<typename Integer, std::enable_if_t<std::is_integral<Integer>::value, bool> = true, std::enable_if_t<std::is_unsigned<Integer>::value, bool> = true>
-	explicit bitflag(const Integer value) : value(static_cast<ENUM_TYPE>(value)) {}
+	explicit constexpr bitflag(const Integer value) : value(static_cast<ENUM_TYPE>(value)) {}
 
-	inline bitflag<ENUM_TYPE> operator~() { return static_cast<ENUM_TYPE>(~static_cast<UNDERLYING_TYPE>(value)); }
-	inline bitflag<ENUM_TYPE> operator|(bitflag<ENUM_TYPE> rhs) const { return static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) | static_cast<UNDERLYING_TYPE>(rhs.value)); }
-	inline bitflag<ENUM_TYPE> operator&(bitflag<ENUM_TYPE> rhs) const { return static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) & static_cast<UNDERLYING_TYPE>(rhs.value)); }
-	inline bitflag<ENUM_TYPE> operator^(bitflag<ENUM_TYPE> rhs) const { return static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) ^ static_cast<UNDERLYING_TYPE>(rhs.value)); }
-	inline bitflag<ENUM_TYPE>& operator|=(bitflag<ENUM_TYPE> rhs) { value = static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) | static_cast<UNDERLYING_TYPE>(rhs.value)); return *this; }
-	inline bitflag<ENUM_TYPE>& operator&=(bitflag<ENUM_TYPE> rhs) { value = static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) & static_cast<UNDERLYING_TYPE>(rhs.value)); return *this; }
-	inline bitflag<ENUM_TYPE>& operator^=(bitflag<ENUM_TYPE> rhs) { value = static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) ^ static_cast<UNDERLYING_TYPE>(rhs.value)); return *this; }
+	inline constexpr bitflag<ENUM_TYPE> operator~() { return static_cast<ENUM_TYPE>(~static_cast<UNDERLYING_TYPE>(value)); }
+	inline constexpr bitflag<ENUM_TYPE> operator|(bitflag<ENUM_TYPE> rhs) const { return static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) | static_cast<UNDERLYING_TYPE>(rhs.value)); }
+	inline constexpr bitflag<ENUM_TYPE> operator&(bitflag<ENUM_TYPE> rhs) const { return static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) & static_cast<UNDERLYING_TYPE>(rhs.value)); }
+	inline constexpr bitflag<ENUM_TYPE> operator^(bitflag<ENUM_TYPE> rhs) const { return static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) ^ static_cast<UNDERLYING_TYPE>(rhs.value)); }
+	inline constexpr bitflag<ENUM_TYPE>& operator|=(bitflag<ENUM_TYPE> rhs) { value = static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) | static_cast<UNDERLYING_TYPE>(rhs.value)); return *this; }
+	inline constexpr bitflag<ENUM_TYPE>& operator&=(bitflag<ENUM_TYPE> rhs) { value = static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) & static_cast<UNDERLYING_TYPE>(rhs.value)); return *this; }
+	inline constexpr bitflag<ENUM_TYPE>& operator^=(bitflag<ENUM_TYPE> rhs) { value = static_cast<ENUM_TYPE>(static_cast<UNDERLYING_TYPE>(value) ^ static_cast<UNDERLYING_TYPE>(rhs.value)); return *this; }
 
-	inline bool hasFlags(bitflag<ENUM_TYPE> val) const { return (static_cast<UNDERLYING_TYPE>(value) & static_cast<UNDERLYING_TYPE>(val.value)) == static_cast<UNDERLYING_TYPE>(val.value); }
+	inline constexpr bool hasFlags(bitflag<ENUM_TYPE> val) const { return (static_cast<UNDERLYING_TYPE>(value) & static_cast<UNDERLYING_TYPE>(val.value)) == static_cast<UNDERLYING_TYPE>(val.value); }
 };
 
 }

--- a/src/nbl/asset/utils/CGLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CGLSLCompiler.cpp
@@ -172,7 +172,7 @@ core::smart_refctd_ptr<ICPUShader> CGLSLCompiler::compileToSPIRV(const char* cod
     shaderc::CompileOptions shadercOptions; //default options
     shadercOptions.SetTargetSpirv(static_cast<shaderc_spirv_version>(glslOptions.targetSpirvVersion));
     const shaderc_shader_kind stage = glslOptions.stage == IShader::ESS_UNKNOWN ? shaderc_glsl_infer_from_source : ESStoShadercEnum(glslOptions.stage);
-    if (glslOptions.genDebugInfo)
+    if (glslOptions.debugInfoFlags.value != IShaderCompiler::E_DEBUG_INFO_FLAGS::EDIF_NONE)
         shadercOptions.SetGenerateDebugInfo();
 
     shaderc::SpvCompilationResult bin_res = comp.CompileGlslToSpv(newCode.c_str(), newCode.size(), stage, glslOptions.preprocessorOptions.sourceIdentifier.data() ? glslOptions.preprocessorOptions.sourceIdentifier.data() : "", "main", shadercOptions);

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -374,8 +374,6 @@ core::smart_refctd_ptr<ICPUShader> CHLSLCompiler::compileToSPIRV(const char* cod
     }
 
     // Debug only values
-
-    arguments.push_back(L"-Qembed_debug");
     if (hlslOptions.debugInfoFlags.hasFlags(E_DEBUG_INFO_FLAGS::EDIF_FILE_BIT))
         arguments.push_back(L"-fspv-debug=file");
     if (hlslOptions.debugInfoFlags.hasFlags(E_DEBUG_INFO_FLAGS::EDIF_SOURCE_BIT))

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -139,7 +139,12 @@ public:
 
 DxcCompilationResult dxcCompile(const CHLSLCompiler* compiler, nbl::asset::hlsl::impl::DXC* dxc, std::string& source, LPCWSTR* args, uint32_t argCount, const CHLSLCompiler::SOptions& options)
 {
-    if (options.genDebugInfo)
+    // Append Commandline options into source only if debugInfoFlags will emit source
+    auto sourceEmittingFlags =
+        CHLSLCompiler::E_DEBUG_INFO_FLAGS::EDIF_SOURCE_BIT |
+        CHLSLCompiler::E_DEBUG_INFO_FLAGS::EDIF_LINE_BIT |
+        CHLSLCompiler::E_DEBUG_INFO_FLAGS::EDIF_NON_SEMANTIC_BIT;
+    if ((options.debugInfoFlags.value & sourceEmittingFlags) != CHLSLCompiler::E_DEBUG_INFO_FLAGS::EDIF_NONE)
     {
         std::ostringstream insertion;
         insertion << "// commandline compiler options : ";
@@ -369,15 +374,18 @@ core::smart_refctd_ptr<ICPUShader> CHLSLCompiler::compileToSPIRV(const char* cod
     }
 
     // Debug only values
-    if (hlslOptions.genDebugInfo)
-    {
-        arguments.insert(arguments.end(), {
-            DXC_ARG_DEBUG,
-            L"-Qembed_debug",
-            // L"-fspv-debug=vulkan-with-source", // disabled because of dxc compiler bugs that don't play nice with this :(
-            L"-fspv-debug=file"
-        });
-    }
+
+    arguments.push_back(L"-Qembed_debug");
+    if (hlslOptions.debugInfoFlags.hasFlags(E_DEBUG_INFO_FLAGS::EDIF_FILE_BIT))
+        arguments.push_back(L"-fspv-debug=file");
+    if (hlslOptions.debugInfoFlags.hasFlags(E_DEBUG_INFO_FLAGS::EDIF_SOURCE_BIT))
+        arguments.push_back(L"-fspv-debug=source");
+    if (hlslOptions.debugInfoFlags.hasFlags(E_DEBUG_INFO_FLAGS::EDIF_LINE_BIT))
+        arguments.push_back(L"-fspv-debug=line");
+    if (hlslOptions.debugInfoFlags.hasFlags(E_DEBUG_INFO_FLAGS::EDIF_TOOL_BIT))
+        arguments.push_back(L"-fspv-debug=tool");
+    if (hlslOptions.debugInfoFlags.hasFlags(E_DEBUG_INFO_FLAGS::EDIF_NON_SEMANTIC_BIT))
+        arguments.push_back(L"-fspv-debug=vulkan-with-source");
 
     auto compileResult = dxcCompile(
         this, 

--- a/src/nbl/video/CVulkanLogicalDevice.h
+++ b/src/nbl/video/CVulkanLogicalDevice.h
@@ -703,7 +703,9 @@ public:
             commonCompileOptions.preprocessorOptions.extraDefines = getExtraShaderDefines();
 
             commonCompileOptions.stage = shaderStage;
-            commonCompileOptions.genDebugInfo = true;
+            commonCompileOptions.debugInfoFlags = 
+                asset::IShaderCompiler::E_DEBUG_INFO_FLAGS::EDIF_SOURCE_BIT |
+                asset::IShaderCompiler::E_DEBUG_INFO_FLAGS::EDIF_TOOL_BIT;
             commonCompileOptions.spirvOptimizer = nullptr; // TODO: create/get spirv optimizer in logical device?
             commonCompileOptions.targetSpirvVersion = m_physicalDevice->getLimits().spirvVersion;
 


### PR DESCRIPTION
## Description
instead of a single bool for genDebugInfo in shader compiler options, we now have a flag with different options mimicking spv debug options of dxc

## Testing 
Tested examplle 62 and 29 where they use the compiler and introspector respectively

## TODO list:
Everything is done

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
