### PR TITLE
Implement debugMarkers

### DIFF
--- a/include/nbl/asset/ICommandBuffer.h
+++ b/include/nbl/asset/ICommandBuffer.h
@@ -307,8 +307,8 @@ public:
     virtual bool copyAccelerationStructureFromMemory(const video::IGPUAccelerationStructure::DeviceCopyFromMemoryInfo& copyInfo) = 0;
     virtual bool executeCommands(uint32_t count, cmdbuf_t* const* const cmdbufs) = 0;
 
-    virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color) = 0;
-    virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color) = 0;
+    virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color = core::vector4df_SIMD(1.0, 1.0, 1.0, 1.0)) = 0;
+    virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color = core::vector4df_SIMD(1.0, 1.0, 1.0, 1.0)) = 0;
     virtual bool endDebugMarker() = 0;
 
 protected:

--- a/include/nbl/asset/ICommandBuffer.h
+++ b/include/nbl/asset/ICommandBuffer.h
@@ -307,6 +307,10 @@ public:
     virtual bool copyAccelerationStructureFromMemory(const video::IGPUAccelerationStructure::DeviceCopyFromMemoryInfo& copyInfo) = 0;
     virtual bool executeCommands(uint32_t count, cmdbuf_t* const* const cmdbufs) = 0;
 
+    virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color) = 0;
+    virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color) = 0;
+    virtual bool endDebugMarker() = 0;
+
 protected:
     ICommandBuffer(E_LEVEL lvl) : m_level(lvl) {}
     virtual ~ICommandBuffer() = default;

--- a/include/nbl/video/CThreadSafeGPUQueueAdapter.h
+++ b/include/nbl/video/CThreadSafeGPUQueueAdapter.h
@@ -37,14 +37,30 @@ class CThreadSafeGPUQueueAdapter : public IGPUQueue
         }
 
         virtual bool startCapture() override 
-        { 
+        {
             std::lock_guard g(m);
             return originalQueue->startCapture();
         }
         virtual bool endCapture() override 
-        { 
+        {
             std::lock_guard g(m);
             return originalQueue->endCapture(); 
+        }
+
+        virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color) override
+        {
+            std::lock_guard g(m);
+            return originalQueue->insertDebugMarker(name, color);
+        }
+        virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color) override
+        {
+            std::lock_guard g(m);
+            return originalQueue->beginDebugMarker(name, color);
+        }
+        virtual bool endDebugMarker() override
+        {
+            std::lock_guard g(m);
+            return originalQueue->endDebugMarker();
         }
 
         IGPUQueue* getUnderlyingQueue() const

--- a/include/nbl/video/CThreadSafeGPUQueueAdapter.h
+++ b/include/nbl/video/CThreadSafeGPUQueueAdapter.h
@@ -47,12 +47,12 @@ class CThreadSafeGPUQueueAdapter : public IGPUQueue
             return originalQueue->endCapture(); 
         }
 
-        virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color) override
+        virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color = core::vector4df_SIMD(1.0, 1.0, 1.0, 1.0)) override
         {
             std::lock_guard g(m);
             return originalQueue->insertDebugMarker(name, color);
         }
-        virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color) override
+        virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color = core::vector4df_SIMD(1.0, 1.0, 1.0, 1.0)) override
         {
             std::lock_guard g(m);
             return originalQueue->beginDebugMarker(name, color);

--- a/include/nbl/video/IGPUQueue.h
+++ b/include/nbl/video/IGPUQueue.h
@@ -51,8 +51,8 @@ class IGPUQueue : public core::Interface, public core::Unmovable
         virtual bool startCapture() = 0;
         virtual bool endCapture() = 0;
 
-        virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color) = 0;
-        virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color) = 0;
+        virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color = core::vector4df_SIMD(1.0, 1.0, 1.0, 1.0)) = 0;
+        virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color = core::vector4df_SIMD(1.0, 1.0, 1.0, 1.0)) = 0;
         virtual bool endDebugMarker() = 0;
 
         //

--- a/include/nbl/video/IGPUQueue.h
+++ b/include/nbl/video/IGPUQueue.h
@@ -51,6 +51,10 @@ class IGPUQueue : public core::Interface, public core::Unmovable
         virtual bool startCapture() = 0;
         virtual bool endCapture() = 0;
 
+        virtual bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color) = 0;
+        virtual bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color) = 0;
+        virtual bool endDebugMarker() = 0;
+
         //
         virtual bool submit(uint32_t _count, const SSubmitInfo* _submits, IGPUFence* _fence) = 0;
 

--- a/include/nbl/video/decl/IBackendObject.h
+++ b/include/nbl/video/decl/IBackendObject.h
@@ -64,6 +64,8 @@ class IBackendObject
 
         const char* getObjectDebugName() const { return m_debugName; }
 
+        // TODO: consider setting tags for backend objects: https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkSetDebugUtilsObjectTagEXT.html
+
     protected:
         virtual ~IBackendObject();
 

--- a/src/nbl/video/CVulkanCommandBuffer.h
+++ b/src/nbl/video/CVulkanCommandBuffer.h
@@ -355,7 +355,50 @@ public:
     bool copyAccelerationStructure_impl(const IGPUAccelerationStructure::CopyInfo& copyInfo) override;
     bool copyAccelerationStructureToMemory_impl(const IGPUAccelerationStructure::DeviceCopyToMemoryInfo& copyInfo) override;
     bool copyAccelerationStructureFromMemory_impl(const IGPUAccelerationStructure::DeviceCopyFromMemoryInfo& copyInfo) override;
-    
+
+    bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color) override final
+    {
+        // This is instance function loaded by volk (via vkGetInstanceProcAddr), so we have to check for validity of the function ptr
+        if (vkCmdInsertDebugUtilsLabelEXT == 0)
+            return false;
+
+        VkDebugUtilsLabelEXT labelInfo = { VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT };
+        labelInfo.pLabelName = name;
+        labelInfo.color[0] = color.x;
+        labelInfo.color[1] = color.y;
+        labelInfo.color[2] = color.z;
+        labelInfo.color[3] = color.w;
+
+        vkCmdBeginDebugUtilsLabelEXT(m_cmdbuf, &labelInfo);
+        return true;
+    }
+
+    bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color) override final
+    {
+        // This is instance function loaded by volk (via vkGetInstanceProcAddr), so we have to check for validity of the function ptr
+        if (vkCmdBeginDebugUtilsLabelEXT == 0)
+            return false;
+        
+        VkDebugUtilsLabelEXT labelInfo = { VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT };
+        labelInfo.pLabelName = name;
+        labelInfo.color[0] = color.x;
+        labelInfo.color[1] = color.y;
+        labelInfo.color[2] = color.z;
+        labelInfo.color[3] = color.w;
+        vkCmdBeginDebugUtilsLabelEXT(m_cmdbuf, &labelInfo);
+
+        return true;
+    }
+
+    bool endDebugMarker() override final
+    {
+        // This is instance function loaded by volk (via vkGetInstanceProcAddr), so we have to check for validity of the function ptr
+        if (vkCmdEndDebugUtilsLabelEXT == 0)
+            return false;
+        vkCmdEndDebugUtilsLabelEXT(m_cmdbuf);
+        return true;
+    }
+
 	inline const void* getNativeHandle() const override {return &m_cmdbuf;}
     VkCommandBuffer getInternalObject() const {return m_cmdbuf;}
 

--- a/src/nbl/video/CVulkanQueue.cpp
+++ b/src/nbl/video/CVulkanQueue.cpp
@@ -126,6 +126,7 @@ bool CVulkanQueue::startCapture()
     m_rdoc_api->StartFrameCapture(RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE(m_vkInstance), NULL);
 	return true;
 }
+
 bool CVulkanQueue::endCapture()
 {
 	if(m_rdoc_api == nullptr)
@@ -133,4 +134,48 @@ bool CVulkanQueue::endCapture()
     m_rdoc_api->EndFrameCapture(RENDERDOC_DEVICEPOINTER_FROM_VKINSTANCE(m_vkInstance), NULL);
 	return true;
 }
+
+bool CVulkanQueue::insertDebugMarker(const char* name, const core::vector4df_SIMD& color)
+{
+    // This is instance function loaded by volk (via vkGetInstanceProcAddr), so we have to check for validity of the function ptr
+    if (vkQueueInsertDebugUtilsLabelEXT == 0)
+        return false;
+
+    VkDebugUtilsLabelEXT labelInfo = { VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT };
+    labelInfo.pLabelName = name;
+    labelInfo.color[0] = color.x;
+    labelInfo.color[1] = color.y;
+    labelInfo.color[2] = color.z;
+    labelInfo.color[3] = color.w;
+
+    vkQueueBeginDebugUtilsLabelEXT(m_vkQueue, &labelInfo);
+    return true;
+}
+
+bool CVulkanQueue::beginDebugMarker(const char* name, const core::vector4df_SIMD& color)
+{
+    // This is instance function loaded by volk (via vkGetInstanceProcAddr), so we have to check for validity of the function ptr
+    if (vkQueueBeginDebugUtilsLabelEXT == 0)
+        return false;
+
+    VkDebugUtilsLabelEXT labelInfo = { VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT };
+    labelInfo.pLabelName = name;
+    labelInfo.color[0] = color.x;
+    labelInfo.color[1] = color.y;
+    labelInfo.color[2] = color.z;
+    labelInfo.color[3] = color.w;
+    vkQueueBeginDebugUtilsLabelEXT(m_vkQueue, &labelInfo);
+
+    return true;
+}
+
+bool CVulkanQueue::endDebugMarker()
+{
+    // This is instance function loaded by volk (via vkGetInstanceProcAddr), so we have to check for validity of the function ptr
+    if (vkQueueEndDebugUtilsLabelEXT == 0)
+        return false;
+    vkQueueEndDebugUtilsLabelEXT(m_vkQueue);
+    return true;
+}
+
 }

--- a/src/nbl/video/CVulkanQueue.h
+++ b/src/nbl/video/CVulkanQueue.h
@@ -25,6 +25,10 @@ public:
     bool startCapture() override;
     bool endCapture() override;
 
+    bool insertDebugMarker(const char* name, const core::vector4df_SIMD& color) override;
+    bool beginDebugMarker(const char* name, const core::vector4df_SIMD& color) override;
+    bool endDebugMarker() override;
+
 private:
     renderdoc_api_t* m_rdoc_api;
 	VkInstance m_vkInstance;


### PR DESCRIPTION
## Description
Implement DebugMarker functionalities in ext_debug_utils extension:
- [vkCmdBeginDebugUtilsLabelEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdBeginDebugUtilsLabelEXT.html)
- [vkCmdEndDebugUtilsLabelEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdEndDebugUtilsLabelEXT.html)
- [vkCmdInsertDebugUtilsLabelEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCmdInsertDebugUtilsLabelEXT.html)
- [vkQueueBeginDebugUtilsLabelEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkQueueBeginDebugUtilsLabelEXT.html)
- [vkQueueEndDebugUtilsLabelEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkQueueEndDebugUtilsLabelEXT.html)
- [vkQueueInsertDebugUtilsLabelEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkQueueInsertDebugUtilsLabelEXT.html)

## Testing 
Tested it in example 62 and capturing via nsight
