### PR TITLE
Change spirv headers path

### DIFF
--- a/3rdparty/dxc/CMakeLists.txt
+++ b/3rdparty/dxc/CMakeLists.txt
@@ -156,15 +156,14 @@ CACHE INTERNAL "")
 if(NBL_EMBED_BUILTIN_RESOURCES)
 	include("${NBL_ROOT_PATH}/src/nbl/builtin/utils.cmake")
 	
-	get_filename_component(_DXC_BR_BUNDLE_SEARCH_DIRECTORY_ "${CMAKE_CURRENT_SOURCE_DIR}" ABSOLUTE)
-	get_filename_component(_DXC_BR_OUTPUT_DIRECTORY_SOURCE_ "${CMAKE_CURRENT_BINARY_DIR}/src" ABSOLUTE)
-	get_filename_component(_DXC_BR_OUTPUT_DIRECTORY_HEADER_ "${CMAKE_CURRENT_BINARY_DIR}/include" ABSOLUTE)
-	set(DXC_BUILTIN_RESOURCES_DIRECTORY_PATH "${_DXC_BR_BUNDLE_SEARCH_DIRECTORY_}" CACHE INTERNAL "")
+	get_filename_component(_SPIRV_BR_BUNDLE_SEARCH_DIRECTORY_ "${CMAKE_CURRENT_SOURCE_DIR}/dxc/external/SPIRV-Headers/include" ABSOLUTE)
+    get_filename_component(_SPIRV_BR_OUTPUT_DIRECTORY_SOURCE_ "${CMAKE_CURRENT_BINARY_DIR}/src" ABSOLUTE)
+    get_filename_component(_SPIRV_BR_OUTPUT_DIRECTORY_HEADER_ "${CMAKE_CURRENT_BINARY_DIR}/include" ABSOLUTE)
 
-	# SPIRV Header in builtin resources, nbl paths as aliases
-	LIST_BUILTIN_RESOURCE(DXC_RESOURCES_TO_EMBED "external/SPIRV-Headers/include/spirv/1.2/spirv.h" "nbl/builtin/hlsl/spirv_intrinsics/spirv.h")
-	LIST_BUILTIN_RESOURCE(DXC_RESOURCES_TO_EMBED "external/SPIRV-Headers/include/spirv/1.2/spirv.hpp" "nbl/builtin/hlsl/spirv_intrinsics/spirv.hpp")
+    # SPIRV Header in builtin resources, nbl paths as aliases
+    LIST_BUILTIN_RESOURCE(SPIRV_RESOURCES_TO_EMBED "1.2/spirv.h")
+    LIST_BUILTIN_RESOURCE(SPIRV_RESOURCES_TO_EMBED "1.2/spirv.hpp")
 
-	ADD_CUSTOM_BUILTIN_RESOURCES(dxcBuiltinResourceData DXC_RESOURCES_TO_EMBED "${_DXC_BR_BUNDLE_SEARCH_DIRECTORY_}" "dxc" "dxc::builtin" "${_DXC_BR_OUTPUT_DIRECTORY_HEADER_}" "${_DXC_BR_OUTPUT_DIRECTORY_SOURCE_}" "STATIC" "INTERNAL")
+    ADD_CUSTOM_BUILTIN_RESOURCES(dxcBuiltinResourceData SPIRV_RESOURCES_TO_EMBED "${_SPIRV_BR_BUNDLE_SEARCH_DIRECTORY_}" "spirv" "spirv::builtin" "${_SPIRV_BR_OUTPUT_DIRECTORY_HEADER_}" "${_SPIRV_BR_OUTPUT_DIRECTORY_SOURCE_}" "STATIC" "INTERNAL")
 endif()
 

--- a/src/nbl/asset/utils/CHLSLCompiler.cpp
+++ b/src/nbl/asset/utils/CHLSLCompiler.cpp
@@ -5,6 +5,7 @@
 #include "nbl/asset/utils/shadercUtils.h"
 #ifdef _NBL_EMBED_BUILTIN_RESOURCES_
 #include "nbl/builtin/CArchive.h"
+#include "spirv/builtin/CArchive.h"
 #endif // _NBL_EMBED_BUILTIN_RESOURCES_
 
 
@@ -76,8 +77,8 @@ static tcpp::IInputStream* getInputStreamInclude(
 
     std::filesystem::path relDir;
     #ifdef _NBL_EMBED_BUILTIN_RESOURCES_
-    const bool reqFromBuiltin = builtin::hasPathPrefix(requestingSource);
-    const bool reqBuiltin = builtin::hasPathPrefix(requestedSource);
+    const bool reqFromBuiltin = nbl::builtin::hasPathPrefix(requestingSource) || spirv::builtin::hasPathPrefix(requestingSource);
+    const bool reqBuiltin = nbl::builtin::hasPathPrefix(requestedSource) || spirv::builtin::hasPathPrefix(requestedSource);
     if (!reqFromBuiltin && !reqBuiltin)
     {
         //While #includ'ing a builtin, one must specify its full path (starting with "nbl/builtin" or "/nbl/builtin").

--- a/src/nbl/system/ISystem.cpp
+++ b/src/nbl/system/ISystem.cpp
@@ -3,7 +3,7 @@
 #include "nbl/system/CFileView.h"
 #ifdef _NBL_EMBED_BUILTIN_RESOURCES_
 #include "nbl/builtin/CArchive.h"
-#include "dxc/builtin/CArchive.h"
+#include "spirv/builtin/CArchive.h"
 #endif // _NBL_EMBED_BUILTIN_RESOURCES_
 
 #include "nbl/system/CArchiveLoaderZip.h"
@@ -20,7 +20,7 @@ ISystem::ISystem(core::smart_refctd_ptr<ISystem::ICaller>&& caller) : m_dispatch
     
     #ifdef _NBL_EMBED_BUILTIN_RESOURCES_
     mount(core::make_smart_refctd_ptr<nbl::builtin::CArchive>(nullptr));
-    mount(core::make_smart_refctd_ptr<dxc::builtin::CArchive>(nullptr));
+    mount(core::make_smart_refctd_ptr<spirv::builtin::CArchive>(nullptr));
     #else
     // TODO: absolute default entry paths? we should do something with it
     mount(core::make_smart_refctd_ptr<nbl::system::CMountDirectoryArchive>(NBL_BUILTIN_RESOURCES_DIRECTORY_PATH, nullptr, this), "nbl/builtin");


### PR DESCRIPTION
Change spirv headers on dxc 3rdparty CMake script to be included using spirv/<VERSION>/<HEADERFILE>

## Description
SPIRV headers are now included using a proper path that matches the file structure under the `include/` dir.

## Testing 
Include any spirv header in a shader such as `spirv/1.2/spirv.h`

## TODO list
-

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
