### PR TITLE
Spirv intrinsics

### DIFF
--- a/include/nbl/builtin/hlsl/spirv_intrinsics/core.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/core.hlsl
@@ -22,74 +22,74 @@ template<>
 [[vk::ext_instruction(spv::OpAtomicIAdd)]]
 int atomicAdd([[vk::ext_reference]] int ptr, uint memoryScope, uint memorySemantics, int value);
 template<>
-[[vk::ext_instruction(/* OpAtomicIAdd */ 234)]]
+[[vk::ext_instruction( spv::OpAtomicIAdd  /*234*/)]]
 uint atomicAdd([[vk::ext_reference]] uint ptr, uint memoryScope, uint memorySemantics, uint value);
 
 template<typename T>
 T atomicAnd([[vk::ext_reference]] T ptr, uint memoryScope, uint memorySemantics, T value);
 template<>
-[[vk::ext_instruction(/* OpAtomicAnd */ 240)]]
+[[vk::ext_instruction( spv::OpAtomicAnd  /*240*/)]]
 int atomicAnd([[vk::ext_reference]] int ptr, uint memoryScope, uint memorySemantics, int value);
 template<>
-[[vk::ext_instruction(/* OpAtomicAnd */ 240)]]
+[[vk::ext_instruction( spv::OpAtomicAnd  /*240*/)]]
 uint atomicAnd([[vk::ext_reference]] uint ptr, uint memoryScope, uint memorySemantics, uint value);
 
 template<typename T>
 T atomicOr([[vk::ext_reference]] T ptr, uint memoryScope, uint memorySemantics, T value);
 template<>
-[[vk::ext_instruction(/* OpAtomicOr */ 241)]]
+[[vk::ext_instruction( spv::OpAtomicOr  /*241*/)]]
 int atomicOr([[vk::ext_reference]] int ptr, uint memoryScope, uint memorySemantics, int value);
 template<>
-[[vk::ext_instruction(/* OpAtomicOr */ 241)]]
+[[vk::ext_instruction( spv::OpAtomicOr  /*241*/)]]
 uint atomicOr([[vk::ext_reference]] uint ptr, uint memoryScope, uint memorySemantics, uint value);
 
 template<typename T>
 T atomicXor([[vk::ext_reference]] T ptr, uint memoryScope, uint memorySemantics, T value);
 template<>
-[[vk::ext_instruction(/* OpAtomicXor */ 242)]]
+[[vk::ext_instruction( spv::OpAtomicXor  /*242*/)]]
 int atomicXor([[vk::ext_reference]] int ptr, uint memoryScope, uint memorySemantics, int value);
 template<>
-[[vk::ext_instruction(/* OpAtomicXor */ 242)]]
+[[vk::ext_instruction( spv::OpAtomicXor  /*242*/)]]
 uint atomicXor([[vk::ext_reference]] uint ptr, uint memoryScope, uint memorySemantics, uint value);
 
 template<typename T>
 T atomicMin([[vk::ext_reference]] T ptr, uint memoryScope, uint memorySemantics, T value);
 template<>
-[[vk::ext_instruction(/* OpAtomicSMin */ 236)]]
+[[vk::ext_instruction( spv::OpAtomicSMin  /*236*/)]]
 int atomicMin([[vk::ext_reference]] int ptr, uint memoryScope, uint memorySemantics, int value);
 template<>
-[[vk::ext_instruction(/* OpAtomicSMin */ 236)]]
+[[vk::ext_instruction( spv::OpAtomicSMin  /*236*/)]]
 uint atomicMin([[vk::ext_reference]] uint ptr, uint memoryScope, uint memorySemantics, uint value);
 
 template<typename T>
 T atomicMax([[vk::ext_reference]] T ptr, uint memoryScope, uint memorySemantics, T value);
 template<>
-[[vk::ext_instruction(/* OpAtomicSMax */ 238)]]
+[[vk::ext_instruction( spv::OpAtomicSMax  /*238*/)]]
 int atomicMax([[vk::ext_reference]] int ptr, uint memoryScope, uint memorySemantics, int value);
 template<>
-[[vk::ext_instruction(/* OpAtomicSMax */ 238)]]
+[[vk::ext_instruction( spv::OpAtomicSMax  /*238*/)]]
 uint atomicMax([[vk::ext_reference]] uint ptr, uint memoryScope, uint memorySemantics, uint value);
 
 template<typename T>
 T atomicExchange([[vk::ext_reference]] T ptr, uint memoryScope, uint memorySemantics, T value);
 template<>
-[[vk::ext_instruction(/* OpAtomicExchange */ 229)]]
+[[vk::ext_instruction( spv::OpAtomicExchange  /*229*/)]]
 int atomicExchange([[vk::ext_reference]] int ptr, uint memoryScope, uint memorySemantics, int value);
 template<>
-[[vk::ext_instruction(/* OpAtomicExchange */ 229)]]
+[[vk::ext_instruction( spv::OpAtomicExchange  /*229*/)]]
 uint atomicExchange([[vk::ext_reference]] uint ptr, uint memoryScope, uint memorySemantics, uint value);
 template<>
-[[vk::ext_instruction(/* OpAtomicExchange */ 229)]]
+[[vk::ext_instruction( spv::OpAtomicExchange  /*229*/)]]
 float atomicExchange([[vk::ext_reference]] float ptr, uint memoryScope, uint memorySemantics, float value);
 
 
 template<typename T>
 T atomicCompSwap([[vk::ext_reference]] T ptr, uint memoryScope, uint memSemanticsEqual, uint memSemanticsUnequal, T value, T comparator);
 template<>
-[[vk::ext_instruction(/* OpAtomicCompareExchange */ 230)]]
+[[vk::ext_instruction( spv::OpAtomicCompareExchange  /*230*/)]]
 int atomicCompSwap([[vk::ext_reference]] int ptr, uint memoryScope, uint memSemanticsEqual, uint memSemanticsUnequal, int value, int comparator);
 template<>
-[[vk::ext_instruction(/* OpAtomicCompareExchange */ 230)]]
+[[vk::ext_instruction( spv::OpAtomicCompareExchange  /*230*/)]]
 uint atomicCompSwap([[vk::ext_reference]] uint ptr, uint memoryScope, uint memSemanticsEqual, uint memSemanticsUnequal, uint value, uint comparator);
 #pragma endregion ATOMICS
 
@@ -99,10 +99,10 @@ uint atomicCompSwap([[vk::ext_reference]] uint ptr, uint memoryScope, uint memSe
 // https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_memory_semantics_id
 // By providing memory semantics None we do both control and memory barrier as is done in GLSL
 
-[[vk::ext_instruction(/* OpControlBarrier */ 224)]]
+[[vk::ext_instruction( spv::OpControlBarrier  /*224*/)]]
 void controlBarrier(uint executionScope, uint memoryScope, uint memorySemantics);
 
-[[vk::ext_instruction(/* OpMemoryBarrier */ 225)]]
+[[vk::ext_instruction( spv::OpMemoryBarrier  /*225*/)]]
 void memoryBarrier(uint memoryScope, uint memorySemantics);
 #pragma endregion BARRIERS
 }

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_arithmetic.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_arithmetic.hlsl
@@ -14,61 +14,61 @@ namespace hlsl
 namespace spirv
 {
 
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(349)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformIAdd /*349*/ )]]
 int groupAdd(uint groupScope, [[vk::ext_literal]] uint operation, int value);
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(349)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformIAdd /*349*/ )]]
 uint groupAdd(uint groupScope, [[vk::ext_literal]] uint operation, uint value);
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(350)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformFAdd /*350*/ )]]
 float groupAdd(uint groupScope, [[vk::ext_literal]] uint operation, float value);
 
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(351)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformIMul /*351*/)]]
 int groupMul(uint groupScope, [[vk::ext_literal]] uint operation, int value);
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(351)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformIMul /*351*/)]]
 uint groupMul(uint groupScope, [[vk::ext_literal]] uint operation, uint value);
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(352)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformFMul /*352*/)]]
 float groupMul(uint groupScope, [[vk::ext_literal]] uint operation, float value);
 
 template<typename T>
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(359)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformBitwiseAnd /*359*/)]]
 T groupBitwiseAnd(uint groupScope, [[vk::ext_literal]] uint operation, T value);
 
 template<typename T>
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(360)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformBitwiseOr /*360*/)]]
 T groupBitwiseOr(uint groupScope, [[vk::ext_literal]] uint operation, T value);
 
 template<typename T>
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(361)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformBitwiseXor /*361*/)]]
 T groupBitwiseXor(uint groupScope, [[vk::ext_literal]] uint operation, T value);
 
 // The MIN and MAX operations in SPIR-V have different Ops for each arithmetic type
 // so we implement them distinctly
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(353)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformSMin /*353*/)]]
 int groupBitwiseMin(uint groupScope, [[vk::ext_literal]] uint operation, int value);
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(354)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformUMin /*354*/)]]
 uint groupBitwiseMin(uint groupScope, [[vk::ext_literal]] uint operation, uint value);
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(355)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformFMin /*355*/)]]
 float groupBitwiseMin(uint groupScope, [[vk::ext_literal]] uint operation, float value);
 
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(356)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformSMax /*356*/)]]
 int groupBitwiseMax(uint groupScope, [[vk::ext_literal]] uint operation, int value);
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(357)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformUMax /*357*/)]]
 uint groupBitwiseMax(uint groupScope, [[vk::ext_literal]] uint operation, uint value);
-[[vk::ext_capability(/* GroupNonUniformArithmetic */ 63)]]
-[[vk::ext_instruction(358)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformArithmetic /*63*/ )]]
+[[vk::ext_instruction( spv::OpGroupNonUniformFMax /*358*/)]]
 float groupBitwiseMax(uint groupScope, [[vk::ext_literal]] uint operation, float value);
 
 }

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_ballot.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_ballot.hlsl
@@ -15,13 +15,13 @@ namespace hlsl
 namespace spirv
 {
 template<typename T>
-[[vk::ext_capability(/* GroupNonUniformBallot */ 64)]]
-[[vk::ext_instruction(/* OpGroupNonUniformBroadcastFirst */ 338)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformBallot  /*64*/)]]
+[[vk::ext_instruction( spv::OpGroupNonUniformBroadcastFirst  /*338*/)]]
 T subgroupBroadcastFirst(uint executionScope, T value);
 
 template<typename T>
-[[vk::ext_capability(/* GroupNonUniformBallot */ 64)]]
-[[vk::ext_instruction(/* OpGroupNonUniformBroadcast */ 337)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformBallot  /*64*/)]]
+[[vk::ext_instruction( spv::OpGroupNonUniformBroadcast  /*337*/)]]
 T subgroupBroadcast(uint executionScope, T value, uint invocationId);
 }
 }

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_basic.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_basic.hlsl
@@ -15,7 +15,7 @@ namespace hlsl
 namespace spirv
 {
 
-[[vk::ext_instruction(/* OpGroupNonUniformElect */ 333)]]
+[[vk::ext_instruction( spv::OpGroupNonUniformElect  /*333*/)]]
 bool subgroupElect(uint executionScope);
 
 }

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_shuffle.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_shuffle.hlsl
@@ -15,18 +15,18 @@ namespace hlsl
 namespace spirv
 {
 template<typename T>
-[[vk::ext_instruction(/* OpGroupNonUniformShuffle */ 345)]]
+[[vk::ext_instruction( spv::OpGroupNonUniformShuffle  /*345*/)]]
 T groupShuffle(uint executionScope, T value, uint invocationId);
 
 #ifdef NBL_GL_KHR_shader_subgroup_shuffle_relative
 template<typename T>
-[[vk::ext_capability(/* GroupNonUniformShuffleRelative */ 66)]]
-[[vk::ext_instruction(/* OpGroupNonUniformShuffleUp */ 347)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformShuffleRelative  /*66*/)]]
+[[vk::ext_instruction( spv::OpGroupNonUniformShuffleUp  /*347*/)]]
 T groupShuffleUp(uint executionScope, T value, uint delta);
 
 template<typename T>
-[[vk::ext_capability(/* GroupNonUniformShuffleRelative */ 66)]]
-[[vk::ext_instruction(/* OpGroupNonUniformShuffleDown */ 348)]]
+[[vk::ext_capability( spv::CapabilityGroupNonUniformShuffleRelative  /*66*/)]]
+[[vk::ext_instruction( spv::OpGroupNonUniformShuffleDown  /*348*/)]]
 T groupShuffleDown(uint executionScope, T value, uint delta);
 #endif
 }


### PR DESCRIPTION
## Description
Replace literal numbers put into vk::ext_instruction and vk::ext_capability with enums from SPIRV-Header(spirv.hpp).