### PR TITLE
Remove #ifdef guard for shuffle relative compatibility...

### DIFF
--- a/include/nbl/builtin/hlsl/glsl_compat/subgroup_shuffle.hlsl
+++ b/include/nbl/builtin/hlsl/glsl_compat/subgroup_shuffle.hlsl
@@ -21,21 +21,13 @@ T subgroupShuffle(T value, uint32_t invocationId)
 template<typename T>
 T subgroupShuffleUp(T value, uint32_t delta)
 {
-#ifdef NBL_GL_KHR_shader_subgroup_shuffle_relative
     return spirv::groupShuffleUp<T>(spv::ScopeSubgroup, value, delta);
-#else
-    return spirv::groupShuffle<T>(spv::ScopeSubgroup, value, gl_SubgroupInvocationID() - delta);
-#endif
 }
 
 template<typename T>
 T subgroupShuffleDown(T value, uint32_t delta)
 {
-#ifdef NBL_GL_KHR_shader_subgroup_shuffle_relative
     return spirv::groupShuffleDown<T>(spv::ScopeSubgroup, value, delta);
-#else
-    return spirv::groupShuffle<T>(spv::ScopeSubgroup, value, gl_SubgroupInvocationID() + delta);
-#endif
 }
 
 }


### PR DESCRIPTION
...since it is now mandatory

## Description
Remove compatibility implementation in case shuffle_relative functionality support is missing since we mandate it now.

## Testing 
N/A

## TODO list:
N/A

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
