### PR TITLE
fix glsl compat code for atomicADD calling spriv atomicAND instead of ADD

### DIFF
--- a/include/nbl/builtin/hlsl/glsl_compat/core.hlsl
+++ b/include/nbl/builtin/hlsl/glsl_compat/core.hlsl
@@ -18,7 +18,7 @@ namespace glsl
 template<typename T>
 T atomicAdd(NBL_REF_ARG(T) ptr, T value)
 {
-    return spirv::atomicAnd<T>(ptr, spv::ScopeDevice, spv::DecorationRelaxedPrecision, value);
+    return spirv::atomicAdd<T>(ptr, spv::ScopeDevice, spv::DecorationRelaxedPrecision, value);
 }
 template<typename T>
 T atomicAnd(NBL_REF_ARG(T) ptr, T value)


### PR DESCRIPTION
## Description
`glsl::atomicAdd` was calling `spirv::atomicAnd`

## Testing 
N/A

## TODO list:
N/A

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
