### PR TITLE
Forgot about these when I pushed the bitfield insert

### DIFF
--- a/include/nbl/builtin/hlsl/type_traits.hlsl
+++ b/include/nbl/builtin/hlsl/type_traits.hlsl
@@ -393,6 +393,12 @@ template<bool B, class T = void>
 using enable_if_t = typename enable_if<B, T>::type;
 
 template<class T>
+NBL_CONSTEXPR_STATIC_INLINE bool is_integral_v = is_integral<T>::value;
+
+template<class T>
+NBL_CONSTEXPR_STATIC_INLINE bool is_scalar_v = is_scalar<T>::value;
+
+template<class T>
 struct alignment_of;
 template<class T>
 NBL_CONSTEXPR_STATIC_INLINE uint32_t alignment_of_v = alignment_of<T>::value;


### PR DESCRIPTION
## Description
Forgot about these I had added to `type_traits.hlsl` which are needed for bitfield insert to work (also for `glsl_compat/core.hlsl` to compile since it has bitfield insert in it now)
