### PR TITLE
fix device headers generation script

### DIFF
--- a/src/nbl/device/DeviceGen.py
+++ b/src/nbl/device/DeviceGen.py
@@ -7,8 +7,8 @@ emptyline = f""
 class ContinueEx(Exception):
     pass
 
-ExposeStatus = IntFlag("Expose", ["DEFAULT", "REQUIRE", "DISABLE", "MOVE_TO_LIMIT"])
-CompareStatus = IntFlag("Compare", ["DEFAULT", "DISABLE", "SKIP", "REVERSE"])
+ExposeStatus = IntFlag("ExposeStatus", ["DEFAULT", "REQUIRE", "DISABLE", "MOVE_TO_LIMIT"])
+CompareStatus = IntFlag("CompareStatus", ["DEFAULT", "DISABLE", "SKIP", "REVERSE"])
 
 MovedLimits = []
 


### PR DESCRIPTION
## Description
fixes an issue where: device headers (_device capabilities traits_ and _physical device features_) are not generated

tested on `python 3.9.0`

**steps to reproduce the issue:**
1. clone Nabla (`git clone --depth 1 git@github.com:Devsh-Graphics-Programming/Nabla.git`)
 or clear existing repo (`git clear -f -d`)
2. [re]generate Visual Studio project with CMake (i.e. `cmake .` in CLI)
3. open `Nabla.sln` solution, build `DeviceHeaders` project

**expected result:**
project generates HLSL and C headers (i.e. `device_capabilities_traits_enums.hlsl`)

**actual result:**
`DeviceGen.py` throws an exception:
```
63>Error while writing to file: E:/Projects/Vulkan/NablaFork/src/nbl/device/include/nbl/video/SPhysicalDeviceFeatures_members.h
63>Exception: name 'Expose' is not defined
63>Traceback (most recent call last):
63>  File "E:\Projects\Vulkan\NablaFork\src\nbl\device\gen.py", line 25, in <module>
63>    writeHeader(
63>  File "E:\Projects\Vulkan\NablaFork\src\nbl\device\DeviceGen.py", line 641, in writeHeader
63>    raise ex
63>  File "E:\Projects\Vulkan\NablaFork\src\nbl\device\DeviceGen.py", line 636, in writeHeader
63>    device_header = header_builder(**params)
63>  File "E:\Projects\Vulkan\NablaFork\src\nbl\device\DeviceGen.py", line 91, in buildDeviceHeader
63>    buildVariable(dict, res, sectionName)
63>  File "E:\Projects\Vulkan\NablaFork\src\nbl\device\DeviceGen.py", line 56, in buildVariable
63>    expose = computeStatus(ExposeStatus, variable["expose"] if "expose" in variable else "DEFAULT")
63>  File "E:\Projects\Vulkan\NablaFork\src\nbl\device\DeviceGen.py", line 16, in computeStatus
63>    return status(eval(sub(r"\w+", lambda s: f"{status[s.group(0)]}", string)))
63>  File "<string>", line 1, in <module>
63>NameError: name 'Expose' is not defined
```

### Applied Fix
matched `IntFlag`'s string literal with value name, now `eval()` expressions refer to correct local values
<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
