### PR TITLE
update getRegions() to return std::span<> instead of core::SRange<>

### DIFF
--- a/include/nbl/asset/ICPUImage.h
+++ b/include/nbl/asset/ICPUImage.h
@@ -67,14 +67,14 @@ class NBL_API2 ICPUImage final : public IImage, public IPreHashed
 		}
 		inline const auto* getBuffer() const { return buffer.get(); }
 
-		inline core::SRange<const IImage::SBufferCopy> getRegions() const
+		inline std::span<const IImage::SBufferCopy> getRegions() const
 		{
 			if (regions)
 				return {regions->begin(),regions->end()};
-			return {nullptr,nullptr};
+			return {};
 		}
 
-		inline core::SRange<const IImage::SBufferCopy> getRegions(uint32_t mipLevel) const
+		inline std::span<const IImage::SBufferCopy> getRegions(uint32_t mipLevel) const
 		{
 			const IImage::SBufferCopy dummy = { 0ull,0u,0u,{static_cast<E_ASPECT_FLAGS>(0u),mipLevel,0u,0u},{},{} };
 			auto begin = std::lower_bound(regions->begin(),regions->end(),dummy,mip_order_t());

--- a/include/nbl/asset/filters/CBasicImageFilterCommon.h
+++ b/include/nbl/asset/filters/CBasicImageFilterCommon.h
@@ -303,32 +303,28 @@ class CBasicImageFilterCommon
 		template<class ExecutionPolicy, typename F, typename G>
 		static inline void executePerRegion(ExecutionPolicy&& policy,
 											const ICPUImage* image, F& f,
-											const IImage::SBufferCopy* _begin,
-											const IImage::SBufferCopy* _end,
+											std::span<const IImage::SBufferCopy> regions,
 											G& g)
 		{
-			for (auto it=_begin; it!=_end; it++)
+			for(auto region : regions)
 			{
-				IImage::SBufferCopy region = *it;
-				if (g(region,it))
+				if (g(region,&region))
 					executePerBlock<ExecutionPolicy,F>(std::forward<ExecutionPolicy>(policy),image,region,f);
 			}
 		}
 		template<typename F, typename G>
 		static inline void executePerRegion(const ICPUImage* image, F& f,
-											const IImage::SBufferCopy* _begin,
-											const IImage::SBufferCopy* _end,
+											std::span<const IImage::SBufferCopy> regions,
 											G& g)
 		{
-			return executePerRegion<const core::execution::sequenced_policy&,F,G>(core::execution::seq,image,f,_begin,_end,g);
+			return executePerRegion<const core::execution::sequenced_policy&,F,G>(core::execution::seq,image,f,regions,g);
 		}
 		template<typename F>
 		static inline void executePerRegion(const ICPUImage* image, F& f,
-											const IImage::SBufferCopy* _begin,
-											const IImage::SBufferCopy* _end)
+											std::span<const IImage::SBufferCopy> regions)
 		{
 			default_region_functor_t voidFunctor;
-			return executePerRegion<F,default_region_functor_t>(image,f,_begin,_end,voidFunctor);
+			return executePerRegion<F,default_region_functor_t>(image,f,regions,voidFunctor);
 		}
 
 	protected:

--- a/include/nbl/asset/filters/CBlitImageFilter.h
+++ b/include/nbl/asset/filters/CBlitImageFilter.h
@@ -445,7 +445,7 @@ class CBlitImageFilter :
 				const ICPUImage::SSubresourceLayers subresource = {static_cast<IImage::E_ASPECT_FLAGS>(0u),outMipLevel,outOffsetLayer.w,1};
 				const IImageFilter::IState::TexelRange range = {outOffset,outExtent};
 				CBasicImageFilterCommon::clip_region_functor_t clip(subresource, range, outFormat);
-				CBasicImageFilterCommon::executePerRegion(policy,outImg,scaleCoverage,outRegions.data(), outRegions.data() + outRegions.size(), clip);
+				CBasicImageFilterCommon::executePerRegion(policy,outImg,scaleCoverage,outRegions, clip);
 			};
 			
 			// process

--- a/include/nbl/asset/filters/CBlitImageFilter.h
+++ b/include/nbl/asset/filters/CBlitImageFilter.h
@@ -379,7 +379,7 @@ class CBlitImageFilter :
 
 				base_t::onEncode(outFormat, state, dstPix, sample, localOutPos, 0, 0, ChannelCount);
 			};
-			const core::SRange<const IImage::SBufferCopy> outRegions = outImg->getRegions(outMipLevel);
+			const std::span<const IImage::SBufferCopy> outRegions = outImg->getRegions(outMipLevel);
 			auto storeToImage = [policy,coverageSemantic,needsNormalization,outExtent,intermediateStorage,&sampler,outFormat,alphaRefValue,outData,intermediateStrides,alphaChannel,storeToTexel,outMipLevel,outOffset,outRegions,outImg,state](
 				const core::rational<int64_t>& coverage, const int axis, const core::vectorSIMDu32& outOffsetLayer
 			) -> void
@@ -445,7 +445,7 @@ class CBlitImageFilter :
 				const ICPUImage::SSubresourceLayers subresource = {static_cast<IImage::E_ASPECT_FLAGS>(0u),outMipLevel,outOffsetLayer.w,1};
 				const IImageFilter::IState::TexelRange range = {outOffset,outExtent};
 				CBasicImageFilterCommon::clip_region_functor_t clip(subresource, range, outFormat);
-				CBasicImageFilterCommon::executePerRegion(policy,outImg,scaleCoverage,outRegions.begin(),outRegions.end(),clip);
+				CBasicImageFilterCommon::executePerRegion(policy,outImg,scaleCoverage,outRegions.data(), outRegions.data() + outRegions.size(), clip);
 			};
 			
 			// process

--- a/include/nbl/asset/filters/CCopyImageFilter.h
+++ b/include/nbl/asset/filters/CCopyImageFilter.h
@@ -68,7 +68,7 @@ class CCopyImageFilter : public CImageFilter<CCopyImageFilter>, public CMatchedS
 					const auto writeOffset = commonExecuteData.oit->getByteOffset(localOutPos,commonExecuteData.outByteStrides);
 					memcpy(commonExecuteData.outData+writeOffset,commonExecuteData.inData+readBlockArrayOffset,commonExecuteData.outBlockByteSize);
 				};
-				CBasicImageFilterCommon::executePerRegion<ExecutionPolicy>(policy,commonExecuteData.inImg,copy,commonExecuteData.inRegions.begin(),commonExecuteData.inRegions.end(),clip);
+				CBasicImageFilterCommon::executePerRegion<ExecutionPolicy>(policy,commonExecuteData.inImg,copy,commonExecuteData.inRegions,clip);
 
 				return true;
 			};

--- a/include/nbl/asset/filters/CFillImageFilter.h
+++ b/include/nbl/asset/filters/CFillImageFilter.h
@@ -51,8 +51,8 @@ class CFillImageFilter : public CImageFilter<CFillImageFilter>
 				state->fillValue.writeMemory(info,blockArrayOffset);
 			};
 			CBasicImageFilterCommon::clip_region_functor_t clip(state->subresource,state->outRange,params.format);
-			const auto& regions = img->getRegions(state->subresource.mipLevel);
-			CBasicImageFilterCommon::executePerRegion(std::forward<ExecutionPolicy>(policy),img,fill,regions.data(),regions.data() + regions.size(),clip);
+			auto regions = img->getRegions(state->subresource.mipLevel);
+			CBasicImageFilterCommon::executePerRegion(std::forward<ExecutionPolicy>(policy),img,fill,regions,clip);
 
 			return true;
 		}

--- a/include/nbl/asset/filters/CFillImageFilter.h
+++ b/include/nbl/asset/filters/CFillImageFilter.h
@@ -52,7 +52,7 @@ class CFillImageFilter : public CImageFilter<CFillImageFilter>
 			};
 			CBasicImageFilterCommon::clip_region_functor_t clip(state->subresource,state->outRange,params.format);
 			const auto& regions = img->getRegions(state->subresource.mipLevel);
-			CBasicImageFilterCommon::executePerRegion(std::forward<ExecutionPolicy>(policy),img,fill,regions.begin(),regions.end(),clip);
+			CBasicImageFilterCommon::executePerRegion(std::forward<ExecutionPolicy>(policy),img,fill,regions.data(),regions.data() + regions.size(),clip);
 
 			return true;
 		}

--- a/include/nbl/asset/filters/CMatchedSizeInOutImageFilterCommon.h
+++ b/include/nbl/asset/filters/CMatchedSizeInOutImageFilterCommon.h
@@ -165,8 +165,8 @@ class CMatchedSizeInOutImageFilterCommon : public CBasicImageFilterCommon
 			const uint32_t outBlockByteSize;
 			const uint8_t* const inData;
 			uint8_t* const outData;
-			const core::SRange<const IImage::SBufferCopy> inRegions;
-			const core::SRange<const IImage::SBufferCopy> outRegions;
+			const std::span<const IImage::SBufferCopy> inRegions;
+			const std::span<const IImage::SBufferCopy> outRegions;
 			const IImage::SBufferCopy* oit;									//!< oit is a current output handled region by commonExecute lambda. Notice that the lambda may execute executePerRegion a few times with different oits data since regions may overlap in a certain mipmap in an image!
 			core::vectorSIMDu32 offsetDifferenceInBlocks;
 			core::vectorSIMDu32 offsetDifferenceInTexels;
@@ -196,8 +196,8 @@ class CMatchedSizeInOutImageFilterCommon : public CBasicImageFilterCommon
 				getTexelOrBlockBytesize(outParams.format),
 				reinterpret_cast<const uint8_t*>(inImg->getBuffer()->getPointer()),
 				reinterpret_cast<uint8_t*>(outImg->getBuffer()->getPointer()),
-				{inRegions.data(), inRegions.data() + inRegions.size()},
-				{outRegions.data(), outRegions.data() + outRegions.size()},
+				inRegions,
+				outRegions,
 				outRegions.data(), {}, {}
 			};
 
@@ -205,7 +205,8 @@ class CMatchedSizeInOutImageFilterCommon : public CBasicImageFilterCommon
 			const asset::TexelBlockInfo dstImageTexelBlockInfo(commonExecuteData.outFormat);
 
 			// iterate over output regions, then input cause read cache miss is faster
-			for (; commonExecuteData.oit!=commonExecuteData.outRegions.end(); commonExecuteData.oit++)
+			const auto endit = commonExecuteData.outRegions.data() + commonExecuteData.outRegions.size();
+			for (; commonExecuteData.oit != endit; commonExecuteData.oit++)
 			{
 				IImage::SSubresourceLayers subresource = {static_cast<IImage::E_ASPECT_FLAGS>(0u),state->inMipLevel,state->inBaseLayer,state->layerCount};
 				state_type::TexelRange range = {state->inOffset,state->extent};

--- a/include/nbl/asset/filters/CMatchedSizeInOutImageFilterCommon.h
+++ b/include/nbl/asset/filters/CMatchedSizeInOutImageFilterCommon.h
@@ -182,7 +182,8 @@ class CMatchedSizeInOutImageFilterCommon : public CBasicImageFilterCommon
 			auto* const outImg = state->outImage;
 			const ICPUImage::SCreationParams& inParams = inImg->getCreationParameters();
 			const ICPUImage::SCreationParams& outParams = outImg->getCreationParameters();
-			const core::SRange<const IImage::SBufferCopy> outRegions = outImg->getRegions(state->outMipLevel);
+			const std::span<const IImage::SBufferCopy> outRegions = outImg->getRegions(state->outMipLevel);
+			const std::span<const IImage::SBufferCopy> inRegions = inImg->getRegions(state->inMipLevel);
 			CommonExecuteData commonExecuteData =
 			{
 				inImg,
@@ -195,9 +196,9 @@ class CMatchedSizeInOutImageFilterCommon : public CBasicImageFilterCommon
 				getTexelOrBlockBytesize(outParams.format),
 				reinterpret_cast<const uint8_t*>(inImg->getBuffer()->getPointer()),
 				reinterpret_cast<uint8_t*>(outImg->getBuffer()->getPointer()),
-				inImg->getRegions(state->inMipLevel),
-				outRegions,
-				outRegions.begin(), {}, {}
+				{inRegions.data(), inRegions.data() + inRegions.size()},
+				{outRegions.data(), outRegions.data() + outRegions.size()},
+				outRegions.data(), {}, {}
 			};
 
 			const asset::TexelBlockInfo srcImageTexelBlockInfo(commonExecuteData.inFormat);

--- a/include/nbl/asset/filters/CRegionBlockFunctorFilter.h
+++ b/include/nbl/asset/filters/CRegionBlockFunctorFilter.h
@@ -45,7 +45,7 @@ class CRegionBlockFunctorFilter : public CImageFilter<CRegionBlockFunctorFilter<
 			if (!state->regionIterator)
 				return false;	
 			const auto& regions = state->image->getRegions();
-			if (state->regionIterator<regions.begin() || state->regionIterator>=regions.end())
+			if (state->regionIterator<regions.data() || state->regionIterator >= regions.data() + regions.size())
 				return false;
 
 			return true;

--- a/include/nbl/asset/filters/CRegionBlockFunctorFilter.h
+++ b/include/nbl/asset/filters/CRegionBlockFunctorFilter.h
@@ -44,8 +44,8 @@ class CRegionBlockFunctorFilter : public CImageFilter<CRegionBlockFunctorFilter<
 
 			if (!state->regionIterator)
 				return false;	
-			const auto& regions = state->image->getRegions();
-			if (state->regionIterator<regions.data() || state->regionIterator >= regions.data() + regions.size())
+			auto regions = state->image->getRegions();
+			if (state->regionIterator < regions.data() || state->regionIterator >= regions.data()+regions.size())
 				return false;
 
 			return true;

--- a/include/nbl/asset/filters/CSummedAreaTableImageFilter.h
+++ b/include/nbl/asset/filters/CSummedAreaTableImageFilter.h
@@ -244,8 +244,8 @@ class CSummedAreaTableImageFilter : public CMatchedSizeInOutImageFilterCommon, p
 					CMatchedSizeInOutImageFilterCommon::state_type::TexelRange range = { state->inOffset,state->extent };
 					CBasicImageFilterCommon::clip_region_functor_t clipFunctor(subresource, range, inFormat);
 
-					const auto& inRegions = state->inImage->getRegions(state->inMipLevel);
-					CBasicImageFilterCommon::executePerRegion(policy, state->inImage, decode, inRegions.begin(), inRegions.end(), clipFunctor);
+					auto inRegions = state->inImage->getRegions(state->inMipLevel);
+					CBasicImageFilterCommon::executePerRegion(policy, state->inImage, decode, inRegions, clipFunctor);
 
 					if constexpr (ExclusiveMode)
 					{
@@ -398,8 +398,8 @@ class CSummedAreaTableImageFilter : public CMatchedSizeInOutImageFilterCommon, p
 						CMatchedSizeInOutImageFilterCommon::state_type::TexelRange range = { state->outOffset,state->extent };
 						CBasicImageFilterCommon::clip_region_functor_t clipFunctor(subresource, range, outFormat);
 
-						const auto& outRegions = state->outImage->getRegions(state->outMipLevel);
-						CBasicImageFilterCommon::executePerRegion(policy,state->outImage, encode, outRegions.begin(), outRegions.end(), clipFunctor);
+						auto outRegions = state->outImage->getRegions(state->outMipLevel);
+						CBasicImageFilterCommon::executePerRegion(policy,state->outImage, encode, outRegions, clipFunctor);
 					}
 				}
 

--- a/include/nbl/asset/filters/CSwizzleAndConvertImageFilter.h
+++ b/include/nbl/asset/filters/CSwizzleAndConvertImageFilter.h
@@ -86,7 +86,7 @@ class CSwizzleAndConvertImageFilterBase : public CSwizzleableAndDitherableFilter
 							state->normalization.prepass(decodeBuffer,readBlockPos*blockDims+commonExecuteData.offsetDifferenceInTexels,blockX,blockY,4u/*TODO: figure this out*/);
 						}
 					};
-					CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, normalizePrepass, commonExecuteData.inRegions.begin(), commonExecuteData.inRegions.end(), clip);
+					CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, normalizePrepass, commonExecuteData.inRegions, clip);
 					return true;
 				};
 				CMatchedSizeInOutImageFilterCommon::commonExecute(state,perOutputRegion);
@@ -164,7 +164,7 @@ class CSwizzleAndConvertImageFilter : public CImageFilter<CSwizzleAndConvertImag
 						base_t::template onEncode<outFormat>(state, dstPix, decodeBuffer, localOutPos, blockX, blockY, outChannelsAmount);
 					}
 				};
-				CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, swizzle, commonExecuteData.inRegions.begin(), commonExecuteData.inRegions.end(), clip);
+				CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, swizzle, commonExecuteData.inRegions, clip);
 				return true;
 			};
 			return CMatchedSizeInOutImageFilterCommon::commonExecute(state,perOutputRegion);
@@ -231,7 +231,7 @@ class CSwizzleAndConvertImageFilter<EF_UNKNOWN,EF_UNKNOWN,Swizzle,Dither,Normali
 						base_t::template onEncode(outFormat, state, dstPix, decodeBuffer, localOutPos, blockX, blockY, outChannelsAmount);
 					}
 				};
-				CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, swizzle, commonExecuteData.inRegions.begin(), commonExecuteData.inRegions.end(), clip);
+				CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, swizzle, commonExecuteData.inRegions, clip);
 				return true;
 			};
 			return CMatchedSizeInOutImageFilterCommon::commonExecute(state,perOutputRegion);
@@ -306,7 +306,7 @@ class CSwizzleAndConvertImageFilter<EF_UNKNOWN,outFormat,Swizzle,Dither,Normaliz
 						base_t::template onEncode<outFormat>(state, dstPix, decodeBuffer, localOutPos, blockX, blockY, outChannelsAmount);
 					}
 				};
-				CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, swizzle, commonExecuteData.inRegions.begin(), commonExecuteData.inRegions.end(), clip);
+				CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, swizzle, commonExecuteData.inRegions, clip);
 				return true;
 			};
 			return CMatchedSizeInOutImageFilterCommon::commonExecute(state, perOutputRegion);
@@ -382,7 +382,7 @@ class CSwizzleAndConvertImageFilter<inFormat,EF_UNKNOWN,Swizzle,Dither,Normaliza
 							base_t::template onEncode(outFormat, state, dstPix, decodeBuffer, localOutPos, blockX, blockY, outChannelsAmount);
 						}
 				};
-				CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, swizzle, commonExecuteData.inRegions.begin(), commonExecuteData.inRegions.end(), clip);
+				CBasicImageFilterCommon::executePerRegion(policy, commonExecuteData.inImg, swizzle, commonExecuteData.inRegions, clip);
 				return true;
 			};
 			return CMatchedSizeInOutImageFilterCommon::commonExecute(state, perOutputRegion);

--- a/include/nbl/asset/filters/dithering/CPrecomputedDither.h
+++ b/include/nbl/asset/filters/dithering/CPrecomputedDither.h
@@ -77,7 +77,7 @@ namespace nbl
 								asset::encodePixels<decodeFormat>(outData + offset, decodeBuffer);
 							};
 
-							CBasicImageFilterCommon::executePerRegion(flattenDitheringImage.get(), decode, flattenDitheringImage->getRegions(chosenMipmap).begin(), flattenDitheringImage->getRegions(chosenMipmap).end());
+							CBasicImageFilterCommon::executePerRegion(flattenDitheringImage.get(), decode, flattenDitheringImage->getRegions(chosenMipmap).data(), flattenDitheringImage->getRegions(chosenMipmap).data() + flattenDitheringImage->getRegions(chosenMipmap).size());
 
 							auto decodeCreationParams = creationParams;
 							decodeCreationParams.format = decodeFormat;
@@ -85,7 +85,7 @@ namespace nbl
 
 							auto decodeFlattenImage = ICPUImage::create(std::move(decodeCreationParams));
 							auto decodeFlattenRegions = core::make_refctd_dynamic_array<core::smart_refctd_dynamic_array<IImage::SBufferCopy>>(1);
-							*decodeFlattenRegions->begin() = *flattenDitheringImage->getRegions().begin();
+							*decodeFlattenRegions->begin() = *flattenDitheringImage->getRegions().data();
 							decodeFlattenRegions->begin()->imageSubresource.baseArrayLayer = 0;
 
 							decodeFlattenImage->setBufferAndRegions(std::move(decodeFlattenBuffer), decodeFlattenRegions);

--- a/include/nbl/asset/filters/dithering/CPrecomputedDither.h
+++ b/include/nbl/asset/filters/dithering/CPrecomputedDither.h
@@ -77,7 +77,7 @@ namespace nbl
 								asset::encodePixels<decodeFormat>(outData + offset, decodeBuffer);
 							};
 
-							CBasicImageFilterCommon::executePerRegion(flattenDitheringImage.get(), decode, flattenDitheringImage->getRegions(chosenMipmap).data(), flattenDitheringImage->getRegions(chosenMipmap).data() + flattenDitheringImage->getRegions(chosenMipmap).size());
+							CBasicImageFilterCommon::executePerRegion(flattenDitheringImage.get(), decode, flattenDitheringImage->getRegions(chosenMipmap));
 
 							auto decodeCreationParams = creationParams;
 							decodeCreationParams.format = decodeFormat;

--- a/include/nbl/asset/interchange/IImageAssetHandlerBase.h
+++ b/include/nbl/asset/interchange/IImageAssetHandlerBase.h
@@ -178,7 +178,7 @@ class IImageAssetHandlerBase : public virtual core::IReferenceCounted
 
 		static inline void performImageFlip(core::smart_refctd_ptr<asset::ICPUImage> image)
 		{
-			bool status = image->getBuffer() && image->getRegions().begin();
+			bool status = image->getBuffer() && image->getRegions().data();
 			assert(status);// , "An image doesn't have a texel buffer and regions attached!");
 
 			auto format = image->getCreationParameters().format;

--- a/src/nbl/asset/ICPUImage.cpp
+++ b/src/nbl/asset/ICPUImage.cpp
@@ -249,7 +249,7 @@ public:
 							blake3_hasher_update(hasher, zeroArray.get(), zeroLength);
 				}
 				else
-					CBasicImageFilterCommon::executePerRegion(std::execution::seq, image, executePerTexelOrBlock, regions.data(), regions.data() + regions.size(), clipFunctor); // fire the hasher for a layer, note we forcing seq policy because texels/blocks cannot be handled with par policies when we hash them
+					CBasicImageFilterCommon::executePerRegion(std::execution::seq, image, executePerTexelOrBlock, regions, clipFunctor); // fire the hasher for a layer, note we forcing seq policy because texels/blocks cannot be handled with par policies when we hash them
 
 				blake3_hasher_finalize(hasher, reinterpret_cast<uint8_t*>(hash), sizeof(CState::hash_t)); // finalize hash for layer + put it to heap for given mip level	
 			};

--- a/src/nbl/asset/ICPUImage.cpp
+++ b/src/nbl/asset/ICPUImage.cpp
@@ -249,7 +249,7 @@ public:
 							blake3_hasher_update(hasher, zeroArray.get(), zeroLength);
 				}
 				else
-					CBasicImageFilterCommon::executePerRegion(std::execution::seq, image, executePerTexelOrBlock, regions.begin(), regions.end(), clipFunctor); // fire the hasher for a layer, note we forcing seq policy because texels/blocks cannot be handled with par policies when we hash them
+					CBasicImageFilterCommon::executePerRegion(std::execution::seq, image, executePerTexelOrBlock, regions.data(), regions.data() + regions.size(), clipFunctor); // fire the hasher for a layer, note we forcing seq policy because texels/blocks cannot be handled with par policies when we hash them
 
 				blake3_hasher_finalize(hasher, reinterpret_cast<uint8_t*>(hash), sizeof(CState::hash_t)); // finalize hash for layer + put it to heap for given mip level	
 			};

--- a/src/nbl/asset/interchange/CGLIWriter.cpp
+++ b/src/nbl/asset/interchange/CGLIWriter.cpp
@@ -205,7 +205,7 @@ bool CGLIWriter::writeGLIFile(system::IFile* file, const asset::ICPUImageView* i
 	};
 
 	const auto& regions = image->getRegions();
-	CBasicImageFilterCommon::executePerRegion<const core::execution::parallel_unsequenced_policy&,decltype(writeTexel),decltype(updateState)>(core::execution::par_unseq,image.get(),writeTexel,regions.data(),regions.data() + regions.size(),updateState);
+	CBasicImageFilterCommon::executePerRegion<const core::execution::parallel_unsequenced_policy&,decltype(writeTexel),decltype(updateState)>(core::execution::par_unseq,image.get(),writeTexel,regions,updateState);
 
 	return performSavingAsIFile(texture, file, m_system.get(), logger);
 }

--- a/src/nbl/asset/interchange/CGLIWriter.cpp
+++ b/src/nbl/asset/interchange/CGLIWriter.cpp
@@ -205,7 +205,7 @@ bool CGLIWriter::writeGLIFile(system::IFile* file, const asset::ICPUImageView* i
 	};
 
 	const auto& regions = image->getRegions();
-	CBasicImageFilterCommon::executePerRegion<const core::execution::parallel_unsequenced_policy&,decltype(writeTexel),decltype(updateState)>(core::execution::par_unseq,image.get(),writeTexel,regions.begin(),regions.end(),updateState);
+	CBasicImageFilterCommon::executePerRegion<const core::execution::parallel_unsequenced_policy&,decltype(writeTexel),decltype(updateState)>(core::execution::par_unseq,image.get(),writeTexel,regions.data(),regions.data() + regions.size(),updateState);
 
 	return performSavingAsIFile(texture, file, m_system.get(), logger);
 }

--- a/src/nbl/asset/interchange/CImageLoaderOpenEXR.cpp
+++ b/src/nbl/asset/interchange/CImageLoaderOpenEXR.cpp
@@ -226,7 +226,7 @@ struct ReadTexels
 			data(reinterpret_cast<uint8_t*>(image->getBuffer()->getPointer())), pixelMapArray(_pixelMapArray)
 		{
 			using StreamFromEXR = CRegionBlockFunctorFilter<ReadTexels<IlmType>,false>;
-			typename StreamFromEXR::state_type state(*this,image,image->getRegions().begin());
+			typename StreamFromEXR::state_type state(*this,image,image->getRegions().data());
 			StreamFromEXR::execute(core::execution::par_unseq,&state);
 		}
 

--- a/src/nbl/asset/interchange/CImageWriterOpenEXR.cpp
+++ b/src/nbl/asset/interchange/CImageWriterOpenEXR.cpp
@@ -148,7 +148,7 @@ bool createAndWriteImage(std::array<ilmType*, availableChannels>& pixelsArrayIlm
 
 	using StreamToEXR = CRegionBlockFunctorFilter<decltype(writeTexel), true>;
 	typename StreamToEXR::state_type state(writeTexel, image, nullptr);
-	for (auto rit = image->getRegions().begin(); rit != image->getRegions().end(); rit++)
+	for (auto rit = image->getRegions().data(); rit != image->getRegions().data() + image->getRegions().size(); rit++)
 	{
 		if (rit->imageSubresource.mipLevel || rit->imageSubresource.baseArrayLayer)
 			continue;

--- a/src/nbl/asset/interchange/CImageWriterOpenEXR.cpp
+++ b/src/nbl/asset/interchange/CImageWriterOpenEXR.cpp
@@ -148,12 +148,12 @@ bool createAndWriteImage(std::array<ilmType*, availableChannels>& pixelsArrayIlm
 
 	using StreamToEXR = CRegionBlockFunctorFilter<decltype(writeTexel), true>;
 	typename StreamToEXR::state_type state(writeTexel, image, nullptr);
-	for (auto rit = image->getRegions().data(); rit != image->getRegions().data() + image->getRegions().size(); rit++)
+	for (auto region : image->getRegions())
 	{
-		if (rit->imageSubresource.mipLevel || rit->imageSubresource.baseArrayLayer)
+		if (region.imageSubresource.mipLevel || region.imageSubresource.baseArrayLayer)
 			continue;
 
-		state.regionIterator = rit;
+		state.regionIterator = &region;
 		StreamToEXR::execute(core::execution::par_unseq, &state);
 	}
 


### PR DESCRIPTION
## Description
shallowly updates `getRegions()` in `ICPUImage.h` (_and methods explicit usages_) to use `std::span<>`

to obtain raw pointers (required by some methods) `<span>.data()` and `<span>.data() + <span>.size()` is used, since it's the only method to access raw pointers without dereferencing iterators
> dereferencing `.end()` iterator may cause address violation segfault
## Testing 
passes 24_ColorSpaceTest (requires a patch - see [0aa4c5](https://github.com/tad1/Nabla-Examples-and-Tests/commit/0aa4c5e7f3a5e3ce6680cbdac7ba022d1d99e8be))
<!-- Explain how this change was tested. -->

## TODO list:
- [x] decide if methods like `CBasicImageFilterCommon::executePerRegion` should use iterators **or** raw pointers (_current_)

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
