### PR TITLE
Inline image content hash computation

### DIFF
--- a/src/nbl/asset/interchange/CGLILoader.cpp
+++ b/src/nbl/asset/interchange/CGLILoader.cpp
@@ -22,6 +22,7 @@ SOFTWARE.
 
 #ifdef _NBL_COMPILE_WITH_GLI_LOADER_
 
+#include "nbl/asset/interchange/CImageHasher.h"
 #include "nbl/asset/interchange/IImageAssetHandlerBase.h"
 
 #ifdef _NBL_COMPILE_WITH_GLI_
@@ -187,24 +188,32 @@ namespace nbl
 			};
 
 			uint64_t tmpDataSizePerRegionSum = {};
+			nbl::asset::CImageHasher contentHasher(imageInfo);
+
 			for (uint16_t mipLevel = 0; mipLevel < imageInfo.mipLevels; ++mipLevel)
 			{
 				const auto layerSize = getFullSizeOfLayer(mipLevel);
+				const auto mipOffset = (mipLevel * imageInfo.arrayLayers);
+
 				for (uint16_t layer = 0; layer < imageInfo.arrayLayers; ++layer)
 				{
 					const auto layersData = getCurrentGliLayerAndFace(layer);
 					const auto gliLayer = layersData.first;
 					const auto gliFace = layersData.second;
+					
+					const auto pOffset = mipOffset + layer;
 
-					assignGLIDataToRegion((reinterpret_cast<uint8_t*>(data) + tmpDataSizePerRegionSum + (layer * layerSize)), texture, gliLayer, gliFace, mipLevel, layerSize);
+					auto regionData = (reinterpret_cast<uint8_t*>(data) + tmpDataSizePerRegionSum + (layer * layerSize));
+					assignGLIDataToRegion(regionData, texture, gliLayer, gliFace, mipLevel, layerSize);
+					
+					contentHasher.hashSeq(mipLevel, layer, regionData, layerSize);
 				}
 				tmpDataSizePerRegionSum += getFullSizeOfRegion(mipLevel);
 			}
 
 			image->setBufferAndRegions(std::move(texelBuffer), regions);
 
-			// TODO: inline hashing while reading
-			auto hash = image->computeContentHash();
+			auto hash = contentHasher.finalizeSeq();
 			image->setContentHash(hash);
 
 			ICPUImageView::SCreationParams imageViewInfo = {};

--- a/src/nbl/asset/interchange/CImageHasher.h
+++ b/src/nbl/asset/interchange/CImageHasher.h
@@ -10,10 +10,50 @@ namespace nbl::asset
 	{
 		public:
 			CImageHasher(const IImage::SCreationParams& _params) 
-				: hashers(std::make_unique<blake3_hasher[]>(_params.arrayLayers * _params.mipLevels)) {}
+				: hashers(std::make_unique<blake3_hasher[]>(_params.arrayLayers * _params.mipLevels)), 
+				imageHasher({ _params.arrayLayers * _params.mipLevels }),
+				arrayLayers(_params.arrayLayers), 
+				mipLevels(_params.mipLevels) 
+			{
+				for(uint32_t i = 0 ; i < _params.arrayLayers * _params.mipLevels; i++){
+					blake3_hasher_init(&hashers[i]);
+				}
+				blake3_hasher_init(&imageHasher);
+			}
 			~CImageHasher() = default;
 
-			std::unique_ptr<blake3_hasher[]> hashers;
+			using hash_t = core::blake3_hash_t;
+			using hasher_t = blake3_hasher;
+
+			std::unique_ptr<hasher_t[]> hashers;
+			hasher_t imageHasher;
+			uint32_t arrayLayers, mipLevels;
+
+			inline void partialHash(uint32_t mipLevel, uint32_t level, void* data, size_t dataLenght) {
+				blake3_hasher_update(&this->hashers[mipLevel * this->arrayLayers + level], data, dataLenght);
+			}
+
+			inline void hashSeq(uint32_t mipLevel, uint32_t level, void* data, size_t dataLenght) {
+				hasher_t* layerHasher = &this->hashers[mipLevel * this->arrayLayers + level];
+				hash_t hash;
+				blake3_hasher_update(layerHasher, data, dataLenght);
+				blake3_hasher_finalize(layerHasher, reinterpret_cast<uint8_t*>(&hash), sizeof(hash_t));
+				blake3_hasher_update(&imageHasher, &hash, sizeof(hash_t));
+			}
+
+			inline void hashSeq(uint32_t mipLevel, uint32_t level) {
+				hasher_t* layerHasher = &this->hashers[mipLevel * this->arrayLayers + level];
+				hash_t hash;
+				blake3_hasher_finalize(layerHasher, reinterpret_cast<uint8_t*>(&hash), sizeof(hash_t));
+				blake3_hasher_update(&imageHasher, &hash, sizeof(hash_t));
+			}
+
+			inline hash_t finalizeSeq() {
+				hash_t hash;
+				blake3_hasher_finalize(&imageHasher, reinterpret_cast<uint8_t*>(&hash), sizeof(hash_t));
+				return hash;
+			}
+
 	};
 }
 

--- a/src/nbl/asset/interchange/CImageLoaderJPG.cpp
+++ b/src/nbl/asset/interchange/CImageLoaderJPG.cpp
@@ -14,6 +14,7 @@
 #include "nbl/asset/ICPUBuffer.h"
 #include "nbl/asset/ICPUImageView.h"
 
+#include "nbl/asset/interchange/CImageHasher.h"
 #include "nbl/asset/interchange/IImageAssetHandlerBase.h"
 
 #include <string>
@@ -288,6 +289,8 @@ asset::SAssetBundle CImageLoaderJPG::loadAsset(system::IFile* _file, const asset
 	}
 	cinfo.do_fancy_upsampling = TRUE;
 	
+	CImageHasher contentHasher(imgInfo);
+
 	// Start decompressor
 	jpeg_start_decompress(&cinfo);
 
@@ -319,17 +322,24 @@ asset::SAssetBundle CImageLoaderJPG::loadAsset(system::IFile* _file, const asset
 
 	// Read rows from bottom order to match OpenGL coords
 	uint32_t rowsRead = 0;
-	while (cinfo.output_scanline < cinfo.output_height)
-		rowsRead += jpeg_read_scanlines(&cinfo, &rowPtr[rowsRead], 1);
+	uint32_t nRead;
+	while (cinfo.output_scanline < cinfo.output_height) {
+		nRead = jpeg_read_scanlines(&cinfo, &rowPtr[rowsRead], 1);
+		//since blake3 implementation greedily fills previous chunks, we can pass data row-wise
+		if (nRead) {
+			contentHasher.partialHash(0, 0, rowPtr[rowsRead], rowspan);
+		}
+		rowsRead += nRead;
+	}
 	
 	// Finish decompression
+	contentHasher.hashSeq(0, 0);
 	jpeg_finish_decompress(&cinfo);
 
 	core::smart_refctd_ptr<ICPUImage> image = ICPUImage::create(std::move(imgInfo));
 	image->setBufferAndRegions(std::move(buffer), regions);
 
-	// TODO: inline hashing while reading
-	auto hash = image->computeContentHash();
+	auto hash = contentHasher.finalizeSeq();
 	image->setContentHash(hash);
 
     return SAssetBundle(nullptr,{image});


### PR DESCRIPTION
## Description
moves content hash computation into image loading loop - for JPEG, GLI (OpenGL Image), OpenEXR (_only these were marked for todo_)
extends `CImageHasher` (adds inline methods for _sequential hash calculation_)

## Testing 
passes `NBL_IMAGE_HASH_RUN_TESTS` with `Debug` configuration

## TODO list:
- [x] test performance of this pull; compare with previous solution (see [#131](https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/pull/131))

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
