### PR TITLE
Adds new DoubleBdaAccessor

### DIFF
--- a/include/nbl/builtin/hlsl/bda/bda_accessor.hlsl
+++ b/include/nbl/builtin/hlsl/bda/bda_accessor.hlsl
@@ -90,22 +90,6 @@ struct DoubleBdaAccessor
         return target.template deref().store(value);
     }
 
-    template<typename S = T>
-    enable_if_t<is_same_v<S,T> && is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), T>
-    atomicAdd(const uint64_t index, const T value)
-    {
-        bda::__ptr<T> target = outputPtr + index;
-        return glsl::atomicAdd(target.template deref().get_ptr(), value);
-    }
-
-    template<typename S = T>
-    enable_if_t<is_same_v<S,T> && is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), T>
-    atomicSub(const uint64_t index, const T value)
-    {
-        bda::__ptr<T> target = outputPtr + index;
-        return glsl::atomicSub(target.template deref().get_ptr(), value);
-    }
-
     bda::__ptr<T> inputPtr, outputPtr;
 };
 

--- a/include/nbl/builtin/hlsl/bda/bda_accessor.hlsl
+++ b/include/nbl/builtin/hlsl/bda/bda_accessor.hlsl
@@ -41,14 +41,16 @@ struct BdaAccessor
         return target.template deref().store(value);
     }
 
-    enable_if_t<is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), T>
+    template<typename S = T>
+    enable_if_t<is_same_v<S,T> && is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), T>
     atomicAdd(const uint64_t index, const T value)
     {
         bda::__ptr<T> target = ptr + index;
         return glsl::atomicAdd(target.template deref().get_ptr(), value);
     }
 
-    enable_if_t<is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), T>
+    template<typename S = T>
+    enable_if_t<is_same_v<S,T> && is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), T>
     atomicSub(const uint64_t index, const T value)
     {
         bda::__ptr<T> target = ptr + index;
@@ -57,6 +59,56 @@ struct BdaAccessor
 
     bda::__ptr<T> ptr;
 };
+
+template<typename T>
+struct DoubleBdaAccessor
+{
+    using type_t = T;
+    static DoubleBdaAccessor<T> create(const bda::__ptr<T> inputPtr, const bda::__ptr<T> outputPtr)
+    {
+        DoubleBdaAccessor<T> accessor;
+        accessor.inputPtr = inputPtr;
+        accessor.outputPtr = outputPtr;
+        return accessor;
+    }
+
+    T get(const uint64_t index)
+    {
+        bda::__ptr<T> target = inputPtr + index;
+        return target.template deref().load();
+    }
+
+    void get(const uint64_t index, NBL_REF_ARG(T) value)
+    {
+        bda::__ptr<T> target = inputPtr + index;
+        value = target.template deref().load();
+    }
+
+    void set(const uint64_t index, const T value)
+    {
+        bda::__ptr<T> target = outputPtr + index;
+        return target.template deref().store(value);
+    }
+
+    template<typename S = T>
+    enable_if_t<is_same_v<S,T> && is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), T>
+    atomicAdd(const uint64_t index, const T value)
+    {
+        bda::__ptr<T> target = outputPtr + index;
+        return glsl::atomicAdd(target.template deref().get_ptr(), value);
+    }
+
+    template<typename S = T>
+    enable_if_t<is_same_v<S,T> && is_integral<T>::value && (sizeof(T) == 4 || sizeof(T) == 8), T>
+    atomicSub(const uint64_t index, const T value)
+    {
+        bda::__ptr<T> target = outputPtr + index;
+        return glsl::atomicSub(target.template deref().get_ptr(), value);
+    }
+
+    bda::__ptr<T> inputPtr, outputPtr;
+};
+
 
 }
 }


### PR DESCRIPTION
## Description
Adds a BdaAccessor variant that reads from a ptr and writes to another ptr. Also templates BdaAccessor's atomics so SFINAE resolution doesn't impede instancing for non-integral accessors

## Testing 
Worked fine replacing the DoublePtr in example 10

## TODO list:
Nothing
