### PR TITLE
Fix `newBuildSystem`'s linker errors

### DIFF
--- a/3rdparty/CMakeLists.txt
+++ b/3rdparty/CMakeLists.txt
@@ -380,6 +380,7 @@ set(NBL_IMMUTABLE_TARGETS # note we have a compiler here we do compile and to si
 	dxcConfig
 	dxcompiler
 	LLVMSupport
+	LLVMMSSupport
 	SPIRV-Tools-static
 	SPIRV-Tools-opt
 )
@@ -439,7 +440,7 @@ if(ANDROID)
 endif()
 
 if(_NBL_COMPILE_WITH_OPEN_EXR_)
-	list(APPEND NBL_3RDPARTY_TARGETS OpenEXR libdeflate_static OpenEXRUtil OpenEXRCore Iex IlmThread)
+	list(APPEND NBL_3RDPARTY_TARGETS OpenEXR libdeflate_static OpenEXRUtil OpenEXRCore Iex IlmThread IlmThreadConfig)
 endif()
 
 if(_NBL_COMPILE_WITH_GLI_)

--- a/3rdparty/boost/CMakeLists.txt
+++ b/3rdparty/boost/CMakeLists.txt
@@ -13,7 +13,7 @@ endforeach()
 
 add_subdirectory(superproject/libs/wave EXCLUDE_FROM_ALL)
 
-list(APPEND NBL_BOOST_TARGETS boost_wave) # wave
+list(APPEND NBL_BOOST_TARGETS boost_wave boost_numeric_conversion) # wave
 foreach(BOOST_LIB IN LISTS NBL_BOOST_LIBS)
 	if(TARGET boost_${BOOST_LIB}) # wave's deps
 		list(APPEND NBL_BOOST_TARGETS boost_${BOOST_LIB})


### PR DESCRIPTION
## Description
Makes `newBuildSystem` build in both modes

## Testing 
Builds Nabla's dynamic target on MSVC w/o `NBL_3RDPARTY_FIND_EXPORTED_TARGETS`, and later with this option set to `ON`

## TODO list:
- [x] fix linker's errors
- [x] consult linker's warrning

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
