### PR TITLE
Fix issue with nabla.h gitinfo

### DIFF
--- a/include/nabla.h
+++ b/include/nabla.h
@@ -17,13 +17,6 @@
 #ifndef __NABLA_H_INCLUDED__
 #define __NABLA_H_INCLUDED__
 
-// meta info
-#include "git_info.h"
-
-namespace nbl {
-	NBL_API2 const gtml::GitInfo& getGitInfo(gtml::E_GIT_REPO_META repo);
-}
-
 // core lib
 #include "nbl/core/declarations.h"
 
@@ -71,5 +64,13 @@ namespace nbl {
 #include "splines.h"
 
 #include "SColor.h"
+
+// meta info
+#include "git_info.h"
+
+namespace nbl {
+	const NBL_API2 gtml::GitInfo& getGitInfo(gtml::E_GIT_REPO_META repo);
+}
+
 
 #endif // __NABLA_H_INCLUDED__


### PR DESCRIPTION
## Description
When compiling Nabla as a DLL, the NBL_API2 macro is being used before it is defined when importing the nabla.h header. This means we can't compile it. I've changed the order around to make sure this works.

## Testing 
<!-- Explain how this change was tested. -->

## TODO list:
<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
