### PR TITLE
Small fix for SPIRV Optimizer + small fix to optimizer pass serialization

### DIFF
--- a/include/nbl/asset/utils/ISPIRVOptimizer.h
+++ b/include/nbl/asset/utils/ISPIRVOptimizer.h
@@ -39,7 +39,7 @@ class ISPIRVOptimizer final : public core::IReferenceCounted
             EOP_COUNT
         };
 
-        ISPIRVOptimizer(std::span<E_OPTIMIZER_PASS> _passes) : m_passes(_passes.begin(), _passes.end()) {}
+        ISPIRVOptimizer(std::span<const E_OPTIMIZER_PASS> _passes) : m_passes(_passes.begin(), _passes.end()) {}
 
         core::smart_refctd_ptr<ICPUBuffer> optimize(const uint32_t* _spirv, uint32_t _dwordCount, system::logger_opt_ptr logger) const;
         core::smart_refctd_ptr<ICPUBuffer> optimize(const ICPUBuffer* _spirv, system::logger_opt_ptr logger) const;

--- a/include/nbl/asset/utils/ISPIRVOptimizer.h
+++ b/include/nbl/asset/utils/ISPIRVOptimizer.h
@@ -24,7 +24,6 @@ class ISPIRVOptimizer final : public core::IReferenceCounted
             EOP_SIMPLIFICATION,
             EOP_VECTOR_DCE,
             EOP_DEAD_INSERT_ELIM,
-            EOP_AGGRESSIVE_DCE,
             EOP_DEAD_BRANCH_ELIM,
             EOP_BLOCK_MERGE,
             EOP_LOCAL_MULTI_STORE_ELIM,
@@ -34,11 +33,13 @@ class ISPIRVOptimizer final : public core::IReferenceCounted
             EOP_REDUCE_LOAD_SIZE,
             EOP_STRENGTH_REDUCTION,
             EOP_IF_CONVERSION,
+            EOP_STRIP_DEBUG_INFO,
+            EOP_AGGRESSIVE_DCE,
 
             EOP_COUNT
         };
 
-        ISPIRVOptimizer(std::initializer_list<E_OPTIMIZER_PASS> _passes) : m_passes(std::move(_passes)) {}
+        ISPIRVOptimizer(core::vector<E_OPTIMIZER_PASS>&& _passes) : m_passes(_passes) {}
 
         core::smart_refctd_ptr<ICPUBuffer> optimize(const uint32_t* _spirv, uint32_t _dwordCount, system::logger_opt_ptr logger) const;
         core::smart_refctd_ptr<ICPUBuffer> optimize(const ICPUBuffer* _spirv, system::logger_opt_ptr logger) const;

--- a/include/nbl/asset/utils/ISPIRVOptimizer.h
+++ b/include/nbl/asset/utils/ISPIRVOptimizer.h
@@ -39,9 +39,7 @@ class ISPIRVOptimizer final : public core::IReferenceCounted
             EOP_COUNT
         };
 
-        ISPIRVOptimizer(std::span<E_OPTIMIZER_PASS> _passes) : m_passes(_passes.size()) {
-            std::copy(_passes.begin(), _passes.end(), m_passes.begin());
-        }
+        ISPIRVOptimizer(std::span<E_OPTIMIZER_PASS> _passes) : m_passes(_passes.begin(), _passes.end()) {}
 
         core::smart_refctd_ptr<ICPUBuffer> optimize(const uint32_t* _spirv, uint32_t _dwordCount, system::logger_opt_ptr logger) const;
         core::smart_refctd_ptr<ICPUBuffer> optimize(const ICPUBuffer* _spirv, system::logger_opt_ptr logger) const;

--- a/include/nbl/asset/utils/ISPIRVOptimizer.h
+++ b/include/nbl/asset/utils/ISPIRVOptimizer.h
@@ -39,7 +39,9 @@ class ISPIRVOptimizer final : public core::IReferenceCounted
             EOP_COUNT
         };
 
-        ISPIRVOptimizer(core::vector<E_OPTIMIZER_PASS>&& _passes) : m_passes(_passes) {}
+        ISPIRVOptimizer(std::span<E_OPTIMIZER_PASS> _passes) : m_passes(_passes.size()) {
+            std::copy(_passes.begin(), _passes.end(), m_passes.begin());
+        }
 
         core::smart_refctd_ptr<ICPUBuffer> optimize(const uint32_t* _spirv, uint32_t _dwordCount, system::logger_opt_ptr logger) const;
         core::smart_refctd_ptr<ICPUBuffer> optimize(const ICPUBuffer* _spirv, system::logger_opt_ptr logger) const;

--- a/src/nbl/asset/utils/ISPIRVOptimizer.cpp
+++ b/src/nbl/asset/utils/ISPIRVOptimizer.cpp
@@ -7,7 +7,7 @@
 
 using namespace nbl::asset;
 
-static constexpr spv_target_env SPIRV_VERSION = spv_target_env::SPV_ENV_UNIVERSAL_1_5;
+static constexpr spv_target_env SPIRV_VERSION = spv_target_env::SPV_ENV_UNIVERSAL_1_6;
 
 nbl::core::smart_refctd_ptr<ICPUBuffer> ISPIRVOptimizer::optimize(const uint32_t* _spirv, uint32_t _dwordCount, system::logger_opt_ptr logger) const
 {
@@ -32,7 +32,6 @@ nbl::core::smart_refctd_ptr<ICPUBuffer> ISPIRVOptimizer::optimize(const uint32_t
         &spvtools::CreateSimplificationPass,
         &spvtools::CreateVectorDCEPass,
         &spvtools::CreateDeadInsertElimPass,
-        //&spvtools::CreateAggressiveDCEPass,
         &spvtools::CreateDeadBranchElimPass,
         &spvtools::CreateBlockMergePass,
         &spvtools::CreateLocalMultiStoreElimPass,
@@ -41,7 +40,9 @@ nbl::core::smart_refctd_ptr<ICPUBuffer> ISPIRVOptimizer::optimize(const uint32_t
         &spvtools::CreateCCPPass,
         CreateReduceLoadSizePass,
         &spvtools::CreateStrengthReductionPass,
-        &spvtools::CreateIfConversionPass
+        &spvtools::CreateIfConversionPass,
+        &spvtools::CreateStripDebugInfoPass,
+        //&spvtools::CreateAggressiveDCEPass
     };
 
     auto msgConsumer = [&logger](spv_message_level_t level, const char* src, const spv_position_t& pos, const char* msg)
@@ -58,7 +59,11 @@ nbl::core::smart_refctd_ptr<ICPUBuffer> ISPIRVOptimizer::optimize(const uint32_t
             system::ILogger::ELL_DEBUG
         };
         const auto lvl = lvl2lvl[level];
-        const std::string location = src + ":"s + std::to_string(pos.line) + ":" + std::to_string(pos.column);
+        std::string location;
+        if (src)
+            location = src + ":"s + std::to_string(pos.line) + ":" + std::to_string(pos.column);
+        else
+            location = "";
 
         logger.log(location, lvl, msg);
     };

--- a/src/nbl/asset/utils/shaderCompiler_serialization.h
+++ b/src/nbl/asset/utils/shaderCompiler_serialization.h
@@ -50,7 +50,7 @@ inline void to_json(json& j, const ISPIRVOptimizer::E_OPTIMIZER_PASS& optPass)
 {
     uint32_t value = static_cast<uint32_t>(optPass);
     j = json{
-        { "optPass", optPass },
+        { "optPass", value },
     };
 }
 


### PR DESCRIPTION
## Description

- There's a disabled optimizer pass so I pushed it to the bottom of the enum (otherwise it fucks up the retrieval later). 
- Update SPIRV version for the optimizer (was at 1.5, now 1.6).
- Change optimizer's message callback so it doesn't crash on nullpointer deref
- Fix a slight overlook when I made serialization of optimizer passes

## Testing 
Added an optimizer pass to my FFT_Bloom example and it worked fine. Caching worked fine as well.
