### PR TITLE
Bitreverse intrinsic

### DIFF
--- a/include/nbl/builtin/hlsl/cpp_compat/impl/intrinsics_impl.hlsl
+++ b/include/nbl/builtin/hlsl/cpp_compat/impl/intrinsics_impl.hlsl
@@ -293,6 +293,42 @@ struct find_msb_return_type<vector<Integer, N> >
 template<typename Integer>
 using find_lsb_return_type = find_msb_return_type<Integer>;
 
+template<typename T NBL_STRUCT_CONSTRAINABLE>
+struct bitReverse_helper;
+
+template<typename Integer>
+NBL_PARTIAL_REQ_TOP(hlsl::is_integral_v<Integer> && hlsl::is_scalar_v<Integer>)
+struct bitReverse_helper<Integer NBL_PARTIAL_REQ_BOT(hlsl::is_integral_v<Integer>&& hlsl::is_scalar_v<Integer>) >
+{
+	static inline Integer __call(NBL_CONST_REF_ARG(Integer) val)
+	{
+#ifdef __HLSL_VERSION
+		return spirv::bitReverse(val);
+#else
+		return glm::bitfieldReverse(val);
+#endif
+	}
+};
+
+template<typename Vector>
+NBL_PARTIAL_REQ_TOP(hlsl::is_vector_v<Vector>)
+struct bitReverse_helper<Vector NBL_PARTIAL_REQ_BOT(hlsl::is_integral_v<Vector> && hlsl::is_vector_v<Vector>) >
+{
+	static Vector __call(NBL_CONST_REF_ARG(Vector) vec)
+	{
+#ifdef __HLSL_VERSION
+		return spirv::bitReverse(vec);
+#else
+		Vector output;
+		using traits = hlsl::vector_traits<Vector>;
+		for (uint32_t i = 0; i < traits::Dimension; ++i)
+			output[i] = bitReverse_helper<scalar_type_t<Vector> >::__call(vec[i]);
+		return output;
+#endif
+	}
+};
+
+
 template<typename T, typename U NBL_STRUCT_CONSTRAINABLE>
 struct lerp_helper;
 

--- a/include/nbl/builtin/hlsl/cpp_compat/intrinsics.hlsl
+++ b/include/nbl/builtin/hlsl/cpp_compat/intrinsics.hlsl
@@ -206,6 +206,17 @@ inline FloatingPoint rsqrt(FloatingPoint x)
 #endif
 }
 
+template<typename Integer>
+inline Integer bitReverse(Integer base)
+{
+#ifdef __HLSL_VERSION
+	return spirv::bitReverse(x);
+#else
+	return glm::bitfieldReverse(x);
+#endif
+}
+
+
 }
 }
 

--- a/include/nbl/builtin/hlsl/cpp_compat/intrinsics.hlsl
+++ b/include/nbl/builtin/hlsl/cpp_compat/intrinsics.hlsl
@@ -207,13 +207,9 @@ inline FloatingPoint rsqrt(FloatingPoint x)
 }
 
 template<typename Integer>
-inline Integer bitReverse(Integer base)
+inline Integer bitReverse(Integer val)
 {
-#ifdef __HLSL_VERSION
-	return spirv::bitReverse(base);
-#else
-	return glm::bitfieldReverse(base);
-#endif
+	return cpp_compat_intrinsics_impl::bitReverse_helper<Integer>::__call(val);
 }
 
 

--- a/include/nbl/builtin/hlsl/cpp_compat/intrinsics.hlsl
+++ b/include/nbl/builtin/hlsl/cpp_compat/intrinsics.hlsl
@@ -210,9 +210,9 @@ template<typename Integer>
 inline Integer bitReverse(Integer base)
 {
 #ifdef __HLSL_VERSION
-	return spirv::bitReverse(x);
+	return spirv::bitReverse(base);
 #else
-	return glm::bitfieldReverse(x);
+	return glm::bitfieldReverse(base);
 #endif
 }
 

--- a/include/nbl/builtin/hlsl/glsl_compat/core.hlsl
+++ b/include/nbl/builtin/hlsl/glsl_compat/core.hlsl
@@ -222,7 +222,7 @@ T bitfieldInsert(T base, T insert, uint32_t offset, uint32_t bits)
 template<typename T>
 T bitfieldReverse(T value)
 {
-    return spirv::bitFieldReverse<T>(value);
+    return spirv::bitReverse<T>(value);
 }
 
 #endif

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/core.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/core.hlsl
@@ -232,7 +232,7 @@ enable_if_t<is_integral_v<Integral>, Integral> bitFieldInsert( Integral base, In
 
 template<typename Integral>
 [[vk::ext_instruction( spv::OpBitReverse )]]
-enable_if_t<is_integral_v<Integral>, Integral> bitFieldReverse( Integral base );
+enable_if_t<is_integral_v<Integral>, Integral> bitReverse( Integral base );
 
 template<typename FloatingPoint>
 [[vk::ext_instruction( spv::OpIsNan )]]


### PR DESCRIPTION
## Description
Adds SPIR-V's `OpBitReverse` intrinsic, using glm's implementation on cpp side

## Testing 
Checked that glm did the same as the spir-v intrinsic by running a small program