### PR TITLE
DXC member decorate, Spir-V 1.4 backports and KHR_fragment_shader_barycentrics support

### DIFF
--- a/include/nbl/asset/utils/CHLSLCompiler.h
+++ b/include/nbl/asset/utils/CHLSLCompiler.h
@@ -146,7 +146,6 @@ class NBL_API2 CHLSLCompiler final : public IShaderCompiler
 			L"-Wno-c++1z-extensions",
 			L"-Wno-c++14-extensions",
 			L"-Wno-gnu-static-float-init",
-			L"-fspv-target-env=vulkan1.3",
 			L"-HV", L"202x"
 		});
 };

--- a/include/nbl/builtin/hlsl/bda/__ref.hlsl
+++ b/include/nbl/builtin/hlsl/bda/__ref.hlsl
@@ -13,7 +13,7 @@ namespace hlsl
 namespace bda
 {
 template<typename T>
-using __spv_ptr_t = spirv::pointer_t<spv::StorageClassPhysicalStorageBuffer,T>;
+using __spv_ptr_t __NBL_CAPABILITY_PhysicalStorageBufferAddresses = spirv::pointer_t<spv::StorageClassPhysicalStorageBuffer,T>;
 
 template<typename T>
 struct __ptr;

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/core.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/core.hlsl
@@ -17,6 +17,40 @@ namespace nbl
 namespace hlsl
 {
 #ifdef __HLSL_VERSION
+
+
+#if __SPIRV_MAJOR_VERSION__>1 || (__SPIRV_MAJOR_VERSION__==1 && __SPIRV_MINOR_VERSION__>=5)
+
+#define __NBL_SPIRV_SUPERSET_1_5__
+
+#define __NBL_CAPABILITY_VulkanMemoryModel [[vk::ext_capability(spv::CapabilityVulkanMemoryModel)]]
+#define __NBL_CAPABILITY_ShaderNonUniform [[vk::ext_capability(spv::CapabilityShaderNonUniform)]]
+#define __NBL_CAPABILITY_PhysicalStorageBufferAddresses [[vk::ext_capability(spv::CapabilityPhysicalStorageBufferAddresses)]]
+// TODO: some poor soul needs to study rest of https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#_capability
+#define __NBL_CAPABILITY_ShaderLayer [[vk::ext_capability(spv::CapabilityShaderLayer)]]
+#define __NBL_CAPABILITY_ShaderViewportIndex [[vk::ext_capability(spv::CapabilityShaderViewportIndex)]]
+
+#else
+
+#define __NBL_CAPABILITY_VulkanMemoryModel [[vk::ext_capability(spv::CapabilityVulkanMemoryModel)]] [[vk::ext_extension("SPV_KHR_vulkan_memory_model")]]
+#define __NBL_CAPABILITY_ShaderNonUniform [[vk::ext_capability(spv::CapabilityShaderNonUniform)]] [[vk::ext_extension("SPV_EXT_descriptor_indexing")]]
+#define __NBL_CAPABILITY_PhysicalStorageBufferAddresses [[vk::ext_capability(spv::CapabilityPhysicalStorageBufferAddresses)]] [[vk::ext_extension("SPV_KHR_physical_storage_buffer")]]
+
+#endif
+
+
+#if __SPIRV_MAJOR_VERSION__>1 || (__SPIRV_MAJOR_VERSION__==1 && __SPIRV_MINOR_VERSION__>=6)
+
+#define __NBL_SPIRV_SUPERSET_1_6__
+
+// 1.6 core caps
+
+#else
+
+// 1.6 core caps and their old extensions
+
+#endif
+
 namespace spirv
 {
 //! General
@@ -171,7 +205,7 @@ enable_if_t<is_spirv_type_v<Ptr_T>, T> atomicCompareExchange(Ptr_T ptr, uint32_t
 
 
 template<typename T, uint32_t alignment>
-[[vk::ext_capability(spv::CapabilityPhysicalStorageBufferAddresses)]]
+__NBL_CAPABILITY_PhysicalStorageBufferAddresses
 [[vk::ext_instruction(spv::OpLoad)]]
 T load(pointer_t<spv::StorageClassPhysicalStorageBuffer,T> pointer, [[vk::ext_literal]] uint32_t __aligned = /*Aligned*/0x00000002, [[vk::ext_literal]] uint32_t __alignment = alignment);
 
@@ -180,7 +214,7 @@ template<typename T, typename P>
 enable_if_t<is_spirv_type_v<P>,T> load(P pointer);
 
 template<typename T, uint32_t alignment>
-[[vk::ext_capability(spv::CapabilityPhysicalStorageBufferAddresses)]]
+__NBL_CAPABILITY_PhysicalStorageBufferAddresses
 [[vk::ext_instruction(spv::OpStore)]]
 void store(pointer_t<spv::StorageClassPhysicalStorageBuffer,T>  pointer, T obj, [[vk::ext_literal]] uint32_t __aligned = /*Aligned*/0x00000002, [[vk::ext_literal]] uint32_t __alignment = alignment);
 
@@ -205,12 +239,12 @@ template<typename T, typename U>
 enable_if_t<is_spirv_type_v<T> && is_spirv_type_v<U>, T> bitcast(U);
 
 template<typename T>
-[[vk::ext_capability(spv::CapabilityPhysicalStorageBufferAddresses)]]
+__NBL_CAPABILITY_PhysicalStorageBufferAddresses
 [[vk::ext_instruction(spv::OpBitcast)]]
 uint64_t bitcast(pointer_t<spv::StorageClassPhysicalStorageBuffer,T>);
 
 template<typename T>
-[[vk::ext_capability(spv::CapabilityPhysicalStorageBufferAddresses)]]
+__NBL_CAPABILITY_PhysicalStorageBufferAddresses
 [[vk::ext_instruction(spv::OpBitcast)]]
 pointer_t<spv::StorageClassPhysicalStorageBuffer,T> bitcast(uint64_t);
 
@@ -269,8 +303,7 @@ enable_if_t<is_vector_v<BooleanVector>&& is_same_v<typename vector_traits<Boolea
 }
 
 #endif
-    }
 }
-
+}
 #endif
 #endif

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/fragment_shader_barycentric.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/fragment_shader_barycentric.hlsl
@@ -1,0 +1,30 @@
+// Copyright (C) 2023 - DevSH Graphics Programming Sp. z O.O.
+// This file is part of the "Nabla Engine".
+// For conditions of distribution and use, see copyright notice in nabla.h
+#ifndef _NBL_BUILTIN_HLSL_SPIRV_INTRINSICS_FRAGMENT_SHADER_BARYCENTRIC_INCLUDED_
+#define _NBL_BUILTIN_HLSL_SPIRV_INTRINSICS_FRAGMENT_SHADER_BARYCENTRIC_INCLUDED_
+
+#include "spirv/unified1/spirv.hpp"
+
+namespace nbl 
+{
+namespace hlsl
+{
+namespace spirv
+{
+
+[[vk::ext_capability(/*spv::CapabilityFragmentBarycentricKHR*/5284)]]
+[[vk::ext_extension("SPV_KHR_fragment_shader_barycentric")]]
+[[vk::ext_builtin_input(/*spv::BuiltInBaryCoordKHR*/5286)]]
+static const float32_t3 BaryCoordKHR;
+
+[[vk::ext_capability(/*spv::CapabilityFragmentBarycentricKHR*/5284)]]
+[[vk::ext_extension("SPV_KHR_fragment_shader_barycentric")]]
+[[vk::ext_builtin_input(/*spv::BuiltInBaryCoordKHR*/5287)]]
+static const float32_t3 BaryCoordNoPerspKHR;
+
+}
+}
+}
+
+#endif

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_arithmetic.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_arithmetic.hlsl
@@ -7,6 +7,9 @@
 // For all WaveMultiPrefix* ops, an example can be found here https://github.com/microsoft/DirectXShaderCompiler/blob/4e5440e1ee1f30d1164f90445611328293de08fa/tools/clang/test/HLSLFileCheck/hlsl/intrinsics/wave/prefix/sm_6_5_wave.hlsl
 // However, we prefer to implement them with SPIRV intrinsics to avoid DXC changes in the compiler's emitted code
 
+
+#include "nbl/builtin/hlsl/spirv_intrinsics/core.hlsl"
+
 namespace nbl 
 {
 namespace hlsl

--- a/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_vote.hlsl
+++ b/include/nbl/builtin/hlsl/spirv_intrinsics/subgroup_vote.hlsl
@@ -5,7 +5,7 @@
 #define _NBL_BUILTIN_HLSL_SPIRV_INTRINSICS_SUBGROUP_VOTE_INCLUDED_
 
 
-#include "nbl/builtin/hlsl/spirv_intrinsics/basic.hlsl"
+#include "nbl/builtin/hlsl/spirv_intrinsics/subgroup_basic.hlsl"
 
 
 namespace nbl 

--- a/src/nbl/builtin/CMakeLists.txt
+++ b/src/nbl/builtin/CMakeLists.txt
@@ -230,6 +230,7 @@ LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "hlsl/matrix_utils/matrix_traits.hl
 #spirv intrinsics
 LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "hlsl/spirv_intrinsics/core.hlsl")
 LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "hlsl/spirv_intrinsics/fragment_shader_pixel_interlock.hlsl")
+LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "hlsl/spirv_intrinsics/fragment_shader_barycentric.hlsl")
 LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "hlsl/spirv_intrinsics/raytracing.hlsl")
 LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "hlsl/spirv_intrinsics/subgroup_arithmetic.hlsl")
 LIST_BUILTIN_RESOURCE(NBL_RESOURCES_TO_EMBED "hlsl/spirv_intrinsics/subgroup_ballot.hlsl")


### PR DESCRIPTION
## Description
<!-- Describe what problem this is solving, and how it's solved. -->

## Testing 
<!-- Explain how this change was tested. -->

## TODO list:
<!-- A list of things that have to be finished before this PR can be merged -->

<!--
By creating this pull request into Nabla, you agree to release all your past (even from previous commits) and present contributions in the Nabla repository under the Apache 2.0 license. If you're not the sole contributor, ensure that all contributors have signed the CLA agreeing to this.
-->
