### PR TITLE
Update DXC for EX40 lexed inline method assert fix

### DIFF
--- a/tools/nsc/manifests/nsc-windows-x64-release.tag
+++ b/tools/nsc/manifests/nsc-windows-x64-release.tag
@@ -1,1 +1,1 @@
-nsc-windows-x64-release-29bda527be490f8214e937ae33bbffd438cce6e6
+nsc-windows-x64-release-eb1bc723b1159029c572f5bf539dafeea03bbbcc

--- a/tools/nsc/manifests/nsc-windows-x64-release/exe/tools/nsc/bin/build-info.json.dvc
+++ b/tools/nsc/manifests/nsc-windows-x64-release/exe/tools/nsc/bin/build-info.json.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: f739d206ca9055781c891f130c6ebc1b
-  size: 1311
+- md5: 27b41f54ba2fbed4e8a0c507e3efb152
+  size: 1337
   hash: md5
   path: build-info.json

--- a/tools/nsc/manifests/nsc-windows-x64-release/exe/tools/nsc/bin/nsc.exe.dvc
+++ b/tools/nsc/manifests/nsc-windows-x64-release/exe/tools/nsc/bin/nsc.exe.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: c4bb7179384f8fe59a5706751a2ef473
+- md5: 2f6ac2e50fe11b36b5a426bcb3b3fa3a
   size: 258048
   hash: md5
   path: nsc.exe

--- a/tools/nsc/manifests/nsc-windows-x64-release/runtime/nbl/3rdparty/dxc/dxcompiler.dll.dvc
+++ b/tools/nsc/manifests/nsc-windows-x64-release/runtime/nbl/3rdparty/dxc/dxcompiler.dll.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 862b11b94cb23c8bac2a20a215eb6597
-  size: 21601280
+- md5: 2f88a872e7e2c9b1c07683f265559b05
+  size: 21609472
   hash: md5
   path: dxcompiler.dll

--- a/tools/nsc/manifests/nsc-windows-x64-release/runtime/nbl/Nabla.dll.dvc
+++ b/tools/nsc/manifests/nsc-windows-x64-release/runtime/nbl/Nabla.dll.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 5edb2790e9ceae424e3c0a04e3d84718
-  size: 29212672
+- md5: f3efa28ec945dae71bf6bbe34331d8ca
+  size: 29222400
   hash: md5
   path: Nabla.dll


### PR DESCRIPTION
## Summary

This updates the DXC submodule to the latest `unroll-devshFixes` tip and includes the lexed inline method ODR-use assert fix on top.

## What changed

- fast-forwarded the DXC line to the current `unroll-devshFixes`
- included the DXC parser fix for stale delayed ODR-use state before lexed inline methods
- pulled in the new small `CodeGenSPIRV` regression test that reproduces the same path

## Why

`40_PathTracer` can hit a DXC debug assert on valid HLSL when declarations such as `[[vk::binding(Bindings::Mask, SessionDSIndex)]]` leave delayed ODR-use bookkeeping behind and the next lexed inline method starts without clearing it.

This branch only updates the DXC pointer for that fix.

## Upstream

- DXC fix PR: https://github.com/microsoft/DirectXShaderCompiler/pull/8324
