### PR TITLE
Classic sincos patch

### DIFF
--- a/include/nbl/builtin/hlsl/math/functions.hlsl
+++ b/include/nbl/builtin/hlsl/math/functions.hlsl
@@ -96,9 +96,8 @@ scalar_type_t<T> lpNorm(NBL_CONST_REF_ARG(T) v)
 template <typename T NBL_FUNC_REQUIRES(concepts::FloatingPointLikeScalar<T>)
 void sincos(T theta, NBL_REF_ARG(T) s, NBL_REF_ARG(T) c)
 {
-    c = cos<T>(theta);
-    s = sqrt<T>(T(NBL_FP64_LITERAL(1.0))-c*c);
-    s = ieee754::flipSign(s, theta < T(NBL_FP64_LITERAL(0.0)));
+    s = sin<T>(theta);
+	c = cos<T>(theta);
 }
 
 template <typename T NBL_FUNC_REQUIRES(vector_traits<T>::Dimension == 3)


### PR DESCRIPTION
It's my understanding that all big vendors run sqrt and sin/cos on the same hardware. So if running sin then cos you saturate the pipeline with sin calls, stall on that, then saturate the pipeline with cos calls. It also allows for vendor-specific optimizations for sincos if those exist.

Current implementation saturates the same pipeline for special functions when calling cos, then goes through FMA twice to compute 1 - c^2, then the same pipeline that would be used for sin but used to compute the sqrt, and then a sign inversion. Not only is it slower (if my understanding is correct) it's also less precise near multiples of pi (although that's probably unimportant near zero).

