### PR TITLE
Add structured stats/IRs to pipeline executable info

### DIFF
--- a/include/nbl/video/IGPUPipeline.h
+++ b/include/nbl/video/IGPUPipeline.h
@@ -12,6 +12,8 @@
 #include "nbl/asset/IPipeline.h"
 #include "nbl/system/to_string.h"
 
+#include <cstddef>
+
 namespace nbl::video
 {
 

--- a/include/nbl/video/IGPUPipeline.h
+++ b/include/nbl/video/IGPUPipeline.h
@@ -128,6 +128,58 @@ class IGPUPipelineBase {
 
         using SShaderEntryMap = SShaderSpecInfo::entry_map_t;
 
+        // One row of VK_KHR_pipeline_executable_properties statistics, kept as the driver
+        // returned it (no formatting, no string scraping). The string field on
+        // SExecutableInfo below is still populated -- this is a parallel, structured view
+        // for callers that need numbers (benchmarks, regressions, baseline diffs).
+        struct SExecutableStatistic
+        {
+            enum class FORMAT : uint8_t { BOOL32, INT64, UINT64, FLOAT64 };
+            std::string name;
+            std::string description;
+            FORMAT      format = FORMAT::UINT64;
+            union Value
+            {
+                bool     b32;
+                int64_t  i64;
+                uint64_t u64;
+                double   f64;
+            } value = {};
+
+            // Convenience: collapse to a uint64_t regardless of the original format.
+            // Matches what most consumers want -- counters, sizes, register tallies.
+            inline uint64_t asUint() const
+            {
+                switch (format)
+                {
+                    case FORMAT::BOOL32:  return value.b32 ? 1u : 0u;
+                    case FORMAT::INT64:   return value.i64 < 0 ? 0u : uint64_t(value.i64);
+                    case FORMAT::UINT64:  return value.u64;
+                    case FORMAT::FLOAT64: return value.f64 < 0.0 ? 0u : uint64_t(value.f64);
+                }
+                return 0u;
+            }
+        };
+
+        // One IR (e.g. SPIR-V, AMD ISA, NV SASS) returned by the driver. Text payloads
+        // are stored without the trailing NUL the driver adds; binary payloads are kept
+        // verbatim. Lets callers dump to a file or hash the data without re-parsing the
+        // pretty-printed blob.
+        struct SInternalRepresentation
+        {
+            std::string             name;
+            std::string             description;
+            bool                    isText = false;
+            core::vector<std::byte> data;
+
+            // View text payloads as a string_view without copying. Empty for binary IRs.
+            inline std::string_view asText() const
+            {
+                if (!isText || data.empty()) return {};
+                return std::string_view(reinterpret_cast<const char*>(data.data()), data.size());
+            }
+        };
+
         // Per-executable info from VK_KHR_pipeline_executable_properties
         struct SExecutableInfo
         {
@@ -135,8 +187,10 @@ class IGPUPipelineBase {
             std::string description;
             core::bitflag<hlsl::ShaderStage> stages = hlsl::ShaderStage::ESS_UNKNOWN;
             uint32_t subgroupSize = 0;
-            std::string statistics;
-            std::string internalRepresentations;
+            std::string statistics;                                              // human-readable, aligned columns; what users log today
+            core::vector<SExecutableStatistic> structuredStatistics;             // same data, structured; for programmatic use
+            std::string internalRepresentations;                                 // human-readable concatenation of IRs (textual ones inline, binaries as "[binary data, N bytes]")
+            core::vector<SInternalRepresentation> structuredInternalRepresentations; // same data, structured; for programmatic use (file dump, hashing, etc.)
         };
 
         inline std::span<const SExecutableInfo> getExecutableInfo() const { return m_executableInfo; }

--- a/src/nbl/video/CVulkanPipelineExecutableInfo.h
+++ b/src/nbl/video/CVulkanPipelineExecutableInfo.h
@@ -6,6 +6,8 @@
 
 #include <volk.h>
 
+#include <cstring>
+
 namespace nbl::video
 {
 
@@ -52,28 +54,45 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 				stats[s] = {VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR, nullptr};
 			vk->vk.vkGetPipelineExecutableStatisticsKHR(vkDevice, &execInfo, &statCount, stats.data());
 
-			// First pass: format name:value pairs and find max width for alignment
+			info.structuredStatistics.resize(statCount);
+
+			// First pass: format name:value pairs (for the human-readable string) and
+			// fill structuredStatistics in lockstep so callers can pick whichever view
+			// they need without re-parsing.
 			core::vector<std::string> nameValues(statCount);
 			size_t maxNameValueLen = 0;
 			for (uint32_t s = 0; s < statCount; ++s)
 			{
 				const auto& stat = stats[s];
+				auto& outStat = info.structuredStatistics[s];
+				outStat.name        = stat.name;
+				outStat.description = stat.description;
+
 				std::string value;
 				switch (stat.format)
 				{
 					case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_BOOL32_KHR:
-						value = stat.value.b32 ? "true" : "false";
+						outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::BOOL32;
+						outStat.value.b32 = stat.value.b32 != VK_FALSE;
+						value = outStat.value.b32 ? "true" : "false";
 						break;
 					case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_INT64_KHR:
+						outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::INT64;
+						outStat.value.i64 = stat.value.i64;
 						value = std::to_string(stat.value.i64);
 						break;
 					case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_UINT64_KHR:
+						outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::UINT64;
+						outStat.value.u64 = stat.value.u64;
 						value = std::to_string(stat.value.u64);
 						break;
 					case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_FLOAT64_KHR:
+						outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::FLOAT64;
+						outStat.value.f64 = stat.value.f64;
 						value = std::to_string(stat.value.f64);
 						break;
 					default:
+						// Unknown format: leave structured value zero, keep raw text marker
 						value = "<unknown format>";
 						break;
 				}
@@ -81,7 +100,7 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 				maxNameValueLen = std::max(maxNameValueLen, nameValues[s].size());
 			}
 
-			// Second pass: emit with aligned columns
+			// Second pass: emit with aligned columns (unchanged human-readable format)
 			std::string& statsStr = info.statistics;
 			for (uint32_t s = 0; s < statCount; ++s)
 			{
@@ -118,24 +137,38 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 
 				vk->vk.vkGetPipelineExecutableInternalRepresentationsKHR(vkDevice, &execInfo, &irCount, irs.data());
 
+				info.structuredInternalRepresentations.resize(irCount);
+
 				std::string& irStr = info.internalRepresentations;
 				for (uint32_t r = 0; r < irCount; ++r)
 				{
+					auto& outIr = info.structuredInternalRepresentations[r];
+					outIr.name        = irs[r].name;
+					outIr.description = irs[r].description;
+					outIr.isText      = irs[r].isText != VK_FALSE;
+					// Text payloads include a trailing NUL per the spec; drop it from the
+					// structured copy so asText().size() matches the textual length.
+					const size_t rawSize  = irs[r].dataSize;
+					const size_t copySize = outIr.isText && rawSize > 0 ? rawSize - 1 : rawSize;
+					outIr.data.resize(copySize);
+					if (copySize > 0)
+						std::memcpy(outIr.data.data(), irs[r].pData, copySize);
+
 					irStr += "---- ";
 					irStr += irs[r].name;
 					irStr += " ----\n";
 					irStr += irs[r].description;
 					irStr += "\n";
-					if (irs[r].isText)
+					if (outIr.isText)
 					{
 						auto* str = static_cast<const char*>(irs[r].pData);
-						irStr.append(str, irs[r].dataSize > 0 ? irs[r].dataSize - 1 : 0);
+						irStr.append(str, copySize);
 						irStr += "\n";
 					}
 					else
 					{
 						irStr += "[binary data, ";
-						irStr += std::to_string(irs[r].dataSize);
+						irStr += std::to_string(rawSize);
 						irStr += " bytes]\n";
 					}
 				}

--- a/src/nbl/video/CVulkanPipelineExecutableInfo.h
+++ b/src/nbl/video/CVulkanPipelineExecutableInfo.h
@@ -18,7 +18,8 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 
 	// Enumerate executables
 	uint32_t executableCount = 0;
-	vk->vk.vkGetPipelineExecutablePropertiesKHR(vkDevice, &pipelineInfo, &executableCount, nullptr);
+	if (vk->vk.vkGetPipelineExecutablePropertiesKHR(vkDevice, &pipelineInfo, &executableCount, nullptr) != VK_SUCCESS)
+		return;
 
 	if (executableCount == 0)
 		return;
@@ -26,7 +27,8 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 	core::vector<VkPipelineExecutablePropertiesKHR> properties(executableCount);
 	for (uint32_t i = 0; i < executableCount; ++i)
 		properties[i] = {VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR, nullptr};
-	vk->vk.vkGetPipelineExecutablePropertiesKHR(vkDevice, &pipelineInfo, &executableCount, properties.data());
+	if (vk->vk.vkGetPipelineExecutablePropertiesKHR(vkDevice, &pipelineInfo, &executableCount, properties.data()) != VK_SUCCESS)
+		return;
 
 	outInfo.resize(executableCount);
 
@@ -45,70 +47,75 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 		execInfo.executableIndex = i;
 
 		uint32_t statCount = 0;
-		vk->vk.vkGetPipelineExecutableStatisticsKHR(vkDevice, &execInfo, &statCount, nullptr);
+		if (vk->vk.vkGetPipelineExecutableStatisticsKHR(vkDevice, &execInfo, &statCount, nullptr) != VK_SUCCESS)
+			statCount = 0;
 
 		if (statCount > 0)
 		{
 			core::vector<VkPipelineExecutableStatisticKHR> stats(statCount);
 			for (uint32_t s = 0; s < statCount; ++s)
 				stats[s] = {VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR, nullptr};
-			vk->vk.vkGetPipelineExecutableStatisticsKHR(vkDevice, &execInfo, &statCount, stats.data());
+			if (vk->vk.vkGetPipelineExecutableStatisticsKHR(vkDevice, &execInfo, &statCount, stats.data()) != VK_SUCCESS)
+				statCount = 0;
 
-			info.structuredStatistics.resize(statCount);
-
-			// First pass: format name:value pairs (for the human-readable string) and
-			// fill structuredStatistics in lockstep so callers can pick whichever view
-			// they need without re-parsing.
-			core::vector<std::string> nameValues(statCount);
-			size_t maxNameValueLen = 0;
-			for (uint32_t s = 0; s < statCount; ++s)
+			if (statCount > 0)
 			{
-				const auto& stat = stats[s];
-				auto& outStat = info.structuredStatistics[s];
-				outStat.name        = stat.name;
-				outStat.description = stat.description;
+				info.structuredStatistics.resize(statCount);
 
-				std::string value;
-				switch (stat.format)
+				// First pass: format name:value pairs (for the human-readable string) and
+				// fill structuredStatistics in lockstep so callers can pick whichever view
+				// they need without re-parsing.
+				core::vector<std::string> nameValues(statCount);
+				size_t maxNameValueLen = 0;
+				for (uint32_t s = 0; s < statCount; ++s)
 				{
-					case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_BOOL32_KHR:
-						outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::BOOL32;
-						outStat.value.b32 = stat.value.b32 != VK_FALSE;
-						value = outStat.value.b32 ? "true" : "false";
-						break;
-					case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_INT64_KHR:
-						outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::INT64;
-						outStat.value.i64 = stat.value.i64;
-						value = std::to_string(stat.value.i64);
-						break;
-					case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_UINT64_KHR:
-						outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::UINT64;
-						outStat.value.u64 = stat.value.u64;
-						value = std::to_string(stat.value.u64);
-						break;
-					case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_FLOAT64_KHR:
-						outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::FLOAT64;
-						outStat.value.f64 = stat.value.f64;
-						value = std::to_string(stat.value.f64);
-						break;
-					default:
-						// Unknown format: leave structured value zero, keep raw text marker
-						value = "<unknown format>";
-						break;
-				}
-				nameValues[s] = std::string(stat.name) + ": " + value;
-				maxNameValueLen = std::max(maxNameValueLen, nameValues[s].size());
-			}
+					const auto& stat = stats[s];
+					auto& outStat = info.structuredStatistics[s];
+					outStat.name        = stat.name;
+					outStat.description = stat.description;
 
-			// Second pass: emit with aligned columns (unchanged human-readable format)
-			std::string& statsStr = info.statistics;
-			for (uint32_t s = 0; s < statCount; ++s)
-			{
-				statsStr += nameValues[s];
-				statsStr.append(maxNameValueLen - nameValues[s].size() + 4, ' ');
-				statsStr += "// ";
-				statsStr += stats[s].description;
-				statsStr += "\n";
+					std::string value;
+					switch (stat.format)
+					{
+						case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_BOOL32_KHR:
+							outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::BOOL32;
+							outStat.value.b32 = stat.value.b32 != VK_FALSE;
+							value = outStat.value.b32 ? "true" : "false";
+							break;
+						case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_INT64_KHR:
+							outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::INT64;
+							outStat.value.i64 = stat.value.i64;
+							value = std::to_string(stat.value.i64);
+							break;
+						case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_UINT64_KHR:
+							outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::UINT64;
+							outStat.value.u64 = stat.value.u64;
+							value = std::to_string(stat.value.u64);
+							break;
+						case VK_PIPELINE_EXECUTABLE_STATISTIC_FORMAT_FLOAT64_KHR:
+							outStat.format    = IGPUPipelineBase::SExecutableStatistic::FORMAT::FLOAT64;
+							outStat.value.f64 = stat.value.f64;
+							value = std::to_string(stat.value.f64);
+							break;
+						default:
+							// Unknown format: leave structured value zero, keep raw text marker
+							value = "<unknown format>";
+							break;
+					}
+					nameValues[s] = std::string(stat.name) + ": " + value;
+					maxNameValueLen = std::max(maxNameValueLen, nameValues[s].size());
+				}
+
+				// Second pass: emit with aligned columns (unchanged human-readable format)
+				std::string& statsStr = info.statistics;
+				for (uint32_t s = 0; s < statCount; ++s)
+				{
+					statsStr += nameValues[s];
+					statsStr.append(maxNameValueLen - nameValues[s].size() + 4, ' ');
+					statsStr += "// ";
+					statsStr += stats[s].description;
+					statsStr += "\n";
+				}
 			}
 		}
 
@@ -116,7 +123,8 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 		if (includeInternalRepresentations)
 		{
 			uint32_t irCount = 0;
-			vk->vk.vkGetPipelineExecutableInternalRepresentationsKHR(vkDevice, &execInfo, &irCount, nullptr);
+			if (vk->vk.vkGetPipelineExecutableInternalRepresentationsKHR(vkDevice, &execInfo, &irCount, nullptr) != VK_SUCCESS)
+				irCount = 0;
 
 			if (irCount > 0)
 			{
@@ -125,7 +133,8 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 					irs[r] = {VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR, nullptr};
 
 				// First call to get sizes
-				vk->vk.vkGetPipelineExecutableInternalRepresentationsKHR(vkDevice, &execInfo, &irCount, irs.data());
+				if (vk->vk.vkGetPipelineExecutableInternalRepresentationsKHR(vkDevice, &execInfo, &irCount, irs.data()) != VK_SUCCESS)
+					continue;
 
 				// Allocate data buffers and second call to get data
 				core::vector<core::vector<char>> irData(irCount);
@@ -135,7 +144,8 @@ inline void populateExecutableInfoFromVulkan(core::vector<IGPUPipelineBase::SExe
 					irs[r].pData = irData[r].data();
 				}
 
-				vk->vk.vkGetPipelineExecutableInternalRepresentationsKHR(vkDevice, &execInfo, &irCount, irs.data());
+				if (vk->vk.vkGetPipelineExecutableInternalRepresentationsKHR(vkDevice, &execInfo, &irCount, irs.data()) != VK_SUCCESS)
+					continue;
 
 				info.structuredInternalRepresentations.resize(irCount);
 


### PR DESCRIPTION

Examples PR: https://github.com/Devsh-Graphics-Programming/Nabla-Examples-and-Tests/pull/279

Since IBenchmark lives in the examples submodule, there's not much here except for the `SExecutableStatistic` struct which is better than having to parse strings to get the info.