### PR TITLE
Fix async queue teardown

### DIFF
--- a/include/nbl/system/IAsyncQueueDispatcher.h
+++ b/include/nbl/system/IAsyncQueueDispatcher.h
@@ -444,6 +444,8 @@ class IAsyncQueueDispatcher : public IThreadHandler<CRTP,InternalStateType>, pro
         request_t request_pool[MaxRequestCount];
         atomic_counter_t cb_begin = 0u;
         atomic_counter_t cb_end = 0u;
+        std::atomic_bool m_acceptsSubmissions = true;
+        atomic_counter_t m_activeSubmissions = 0u;
 
         static inline counter_t wrapAround(counter_t x)
         {
@@ -470,6 +472,10 @@ class IAsyncQueueDispatcher : public IThreadHandler<CRTP,InternalStateType>, pro
         template<typename T, typename... Args>
         void request(future_t<T>* _future, Args&&... args)
         {
+            if (!beginSubmission())
+                return;
+            auto submissionCleanup = core::makeRAIIExiter([this]() -> void { this->finishSubmission(); });
+
             // get next output index
             const auto virtualIx = cb_end++;
             // protect against overflow by waiting for the worker to catch up
@@ -493,6 +499,17 @@ class IAsyncQueueDispatcher : public IThreadHandler<CRTP,InternalStateType>, pro
         }
 
     protected:
+        inline void shutdown()
+        {
+            if (!beginShutdown())
+                return;
+
+            // accepted submissions must publish cb_end before drain observes the queue
+            waitForSubmissions();
+            drain();
+            base_t::stopThread();
+        }
+
         inline ~IAsyncQueueDispatcher()
         {
             const auto begin = cb_begin.load();
@@ -505,6 +522,56 @@ class IAsyncQueueDispatcher : public IThreadHandler<CRTP,InternalStateType>, pro
         inline void background_work() {}
 
     private:
+        inline bool beginSubmission()
+        {
+            // register first, so shutdown can't miss a request already entering submission
+            m_activeSubmissions.fetch_add(1u);
+
+            const bool acceptsRequests = m_acceptsSubmissions.load();
+            assert(acceptsRequests);
+            if (!acceptsRequests)
+            {
+                finishSubmission();
+                return false;
+            }
+            return true;
+        }
+
+        inline void finishSubmission()
+        {
+            const auto previousSubmissions = m_activeSubmissions.fetch_sub(1u);
+            assert(previousSubmissions!=0u);
+            m_activeSubmissions.notify_all();
+        }
+
+        inline bool beginShutdown()
+        {
+            return m_acceptsSubmissions.exchange(false);
+        }
+
+        inline void waitForSubmissions()
+        {
+            for (auto submissions=m_activeSubmissions.load(); submissions!=0u; submissions=m_activeSubmissions.load())
+                m_activeSubmissions.wait(submissions);
+        }
+
+        inline void drain()
+        {
+            while (true)
+            {
+                const auto begin = cb_begin.load();
+                const auto end = cb_end.load();
+                if (begin==end)
+                    return;
+
+                {
+                    auto global_lk = base_t::createLock();
+                    base_t::m_cvar.notify_one();
+                }
+                cb_begin.wait(begin);
+            }
+        }
+
         template<typename... Args>
         void work(lock_t& lock, Args&&... optional_internal_state)
         {

--- a/include/nbl/system/IAsyncQueueDispatcher.h
+++ b/include/nbl/system/IAsyncQueueDispatcher.h
@@ -61,8 +61,13 @@ class IAsyncQueueDispatcherBase
                 inline request_base_t() = default;
                 inline ~request_base_t()
                 {
-                    // fully cleaned up
-                    assert(!future);
+                    const auto currentState = state.query();
+                    const bool hasNoFuture = future==nullptr;
+                    const bool isInitial = currentState==STATE::INITIAL;
+
+                    // Dispatcher storage may only destroy fully recycled request slots.
+                    assert(hasNoFuture);
+                    assert(isInitial);
                 }
 
                 // ban certain operators
@@ -488,7 +493,15 @@ class IAsyncQueueDispatcher : public IThreadHandler<CRTP,InternalStateType>, pro
         }
 
     protected:
-        inline ~IAsyncQueueDispatcher() {}
+        inline ~IAsyncQueueDispatcher()
+        {
+            const auto begin = cb_begin.load();
+            const auto end = cb_end.load();
+            const bool isIdle = begin==end;
+
+            // Request storage must not be destroyed while queued work is still pending.
+            assert(isIdle);
+        }
         inline void background_work() {}
 
     private:

--- a/include/nbl/system/ISystem.h
+++ b/include/nbl/system/ISystem.h
@@ -274,6 +274,10 @@ class NBL_API2 ISystem : public core::IReferenceCounted
                 {
                     //waitForInitComplete(); init is a NOOP
                 }
+                inline ~CAsyncQueue()
+                {
+                    this->shutdown();
+                }
 
                 void process_request(base_t::future_base_t* _future_base, SRequestType& req);
 

--- a/include/nbl/system/IThreadHandler.h
+++ b/include/nbl/system/IThreadHandler.h
@@ -165,6 +165,11 @@ class IThreadHandler
         }
 
     protected:
+        void stopThread()
+        {
+            terminate();
+        }
+
         void thread()
         {
             CRTP* this_ = static_cast<CRTP*>(this);

--- a/src/nbl/ui/CWindowManagerWin32.h
+++ b/src/nbl/ui/CWindowManagerWin32.h
@@ -202,6 +202,10 @@ class NBL_API2 CWindowManagerWin32 final : public IWindowManagerWin32, public IC
 				{
 					//waitForInitComplete(); init is a NOOP
 				}
+				inline ~CAsyncQueue()
+				{
+					this->shutdown();
+				}
 
 				inline void init() {}
 


### PR DESCRIPTION
## Summary

Fix async queue teardown by draining accepted work before request storage is destroyed.

## Root cause

The lifecycle issue comes from [`9414a480ffe`](https://github.com/Devsh-Graphics-Programming/Nabla/commit/9414a480ffe51686903e7a809a564d9012ca9ef5), where `IThreadHandler` started stopping its worker thread from the base destructor. For CRTP queue users this is too late because derived resources and request storage are destroyed first.

Later async queue changes in [`de28767cc1`](https://github.com/Devsh-Graphics-Programming/Nabla/commit/de28767cc1dd5931e8f0d95ba521868b7f35feca), [`418db0d4c1`](https://github.com/Devsh-Graphics-Programming/Nabla/commit/418db0d4c1ec563171f4ecdedd9499dddbd7b0b9), and [`87eeacb250`](https://github.com/Devsh-Graphics-Programming/Nabla/commit/87eeacb2502abdab30ce699c4177c43e8af37d5d) kept the same lifetime model while request slots started carrying associated futures and cancelled requests relied on the worker for cleanup. That made the old teardown ordering visible as an intermittent Debug assert when `request_pool` was destroyed before all slots were recycled.

This matches the random failure seen around [#1079](https://github.com/Devsh-Graphics-Programming/Nabla/pull/1079). It is a queue lifecycle bug, not a DXC compile failure.

## Fix

Queue owners now call `shutdown()` from their own destructors. Shutdown closes submissions, waits for active `request()` calls to finish publishing, drains pending and cancelled slots, and only then stops the worker thread.