### PR TITLE
Photon Caustics example with Raytracing shaders + minor nabla fixes

### DIFF
--- a/include/nbl/video/IGPURayTracingPipeline.h
+++ b/include/nbl/video/IGPURayTracingPipeline.h
@@ -84,7 +84,7 @@ class IGPURayTracingPipeline :  public IGPUPipeline<asset::IRayTracingPipeline<c
                     }
 
                     // https://docs.vulkan.org/spec/latest/chapters/pipelines.html#VUID-VkRayTracingPipelineCreateInfoKHR-flags-03471
-                    if (cached.flags.hasFlags(FLAGS::NO_NULL_CLOSEST_HIT_SHADERS) && !shaderGroup.intersection.shader)
+                    if (cached.flags.hasFlags(FLAGS::NO_NULL_CLOSEST_HIT_SHADERS) && !shaderGroup.closestHit.shader)
                         return {};
                 }
 

--- a/src/nbl/video/CVulkanRayTracingPipeline.cpp
+++ b/src/nbl/video/CVulkanRayTracingPipeline.cpp
@@ -19,7 +19,7 @@ namespace nbl::video
     m_shaderGroupHandles(std::move(shaderGroupHandles)),
     m_missStackSizes(core::make_refctd_dynamic_array<GeneralGroupStackSizeContainer>(params.shaderGroups.misses.size())),
     m_hitGroupStackSizes(core::make_refctd_dynamic_array<HitGroupStackSizeContainer>(params.shaderGroups.hits.size())),
-    m_callableStackSizes(core::make_refctd_dynamic_array<GeneralGroupStackSizeContainer>(params.shaderGroups.hits.size()))
+    m_callableStackSizes(core::make_refctd_dynamic_array<GeneralGroupStackSizeContainer>(params.shaderGroups.callables.size()))
   {
     const auto* vulkanDevice = static_cast<const CVulkanLogicalDevice*>(getOriginDevice());
     auto* vk = vulkanDevice->getFunctionTable();


### PR DESCRIPTION
## Description
The goal of this example is to implement basics caustics using photon mapping, the sample uses raytracing shaders to implement a simple path traces and extends that to building a photon map for tracing caustics in the path tracing pass during scene shading. We use 2 ray tracing passes:
1. Photons tracing for emissive triangles in the scene build from the TLAS/BLAS
2. uses the static photon map to trace radiance during non caustics path.
3. uses reflect/refract for simple metals/glass materials no fancy BxDF evaluation
4. Uses static scene and lights for path tracing the scene

### Photon map based on jensens specular concentration
Photon emission is aimed with a projection map rather than sampling the full hemisphere, photons are cone-sampled toward the bounding sphere of specular geometry. This reduces spreading of photon over the entire scene and focues them over specular emissive geometry.

### Optimizing with spatial hashmap
The gather at shading time is accelerated with a uniform spatial grid, the example build a 16x16x16 spatial hash grid and stores photon using InterlockedAdd during the photonMap build pass. We use this during the gatherPhoton in raytraces scene shading pass to gather photons from nearby cells that cover the range of each photon radius.

### Extra
- Also added debug views to visualize raw photon density.
- Toggle to disable caustics path in the simple raytracer path 
- Reset camera toggle and other photon map config in ImGui

## Nabla Bug Fixes
Fixed some types in IGPURayTracingPipeline shadergroups, this was caught when we used only rcgen/rcmiss/rchit shaders, unlike other samples that used all the shader stages available. 

<img width="1914" height="1112" alt="image" src="https://github.com/user-attachments/assets/c731160c-1544-447f-a6a5-18d14b8efd4b" />
<img width="1914" height="1102" alt="image" src="https://github.com/user-attachments/assets/7c7ce9c9-bef6-4ca3-8ce1-90306acc3a18" />
<img width="1913" height="1111" alt="image" src="https://github.com/user-attachments/assets/9fe8227b-0d3b-45a6-86ab-9e42b65d794f" />

